### PR TITLE
Fix the deprecated warning of URI.escape in Ruby 2.7

### DIFF
--- a/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
+++ b/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
@@ -1,3 +1,5 @@
+require "addressable/uri"
+
 module Paperclip
   class HttpUrlProxyAdapter < UriAdapter
     def self.register
@@ -9,8 +11,8 @@ module Paperclip
     REGEXP = /\Ahttps?:\/\//.freeze
 
     def initialize(target, options = {})
-      escaped = URI.escape(target)
-      super(URI(target == URI.unescape(target) ? escaped : target), options)
+      escaped = Addressable::URI.escape(target)
+      super(URI(target == Addressable::URI.unescape(target) ? escaped : target), options)
     end
   end
 end

--- a/lib/paperclip/url_generator.rb
+++ b/lib/paperclip/url_generator.rb
@@ -1,5 +1,6 @@
 require "uri"
 require "active_support/core_ext/module/delegation"
+require "addressable/uri"
 
 module Paperclip
   class UrlGenerator
@@ -65,7 +66,7 @@ module Paperclip
       if url.respond_to?(:escape)
         url.escape
       else
-        URI.escape(url).gsub(escape_regex) { |m| "%#{m.ord.to_s(16).upcase}" }
+        Addressable::URI.escape(url).gsub(escape_regex) { |m| "%#{m.ord.to_s(16).upcase}" }
       end
     end
 

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency("mime-types")
   s.add_dependency("mimemagic", "~> 0.3.0")
   s.add_dependency("terrapin", "~> 0.6.0")
+  s.add_dependency("addressable")
 
   s.add_development_dependency("activerecord", ">= 4.2.0")
   s.add_development_dependency("appraisal")


### PR DESCRIPTION
Ruby(>= 2.7) throws the many deprecated warning about URI.escape & URI.unescape to logfiles or rspec outputs.

But now there is no easy alternative way to replace the methods in Ruby's standard features.

So I used `Addressable::URI.escape` in [sporkmonger/addressable](https://github.com/sporkmonger/addressable) which is an alternative implementation to the URI implementation that is part of Ruby's standard library and is developed continuously even now.

