### PR TITLE
Add `validation_errors_to` options - customize copying of errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Example Usage:
 validates_attachment_presence :avatar
 ```
 
-Lastly, you can also define multiple validations on a single attachment using `validates_attachment`:
+You can also define multiple validations on a single attachment using `validates_attachment`:
 
 ```ruby
 validates_attachment :avatar, presence: true,
@@ -409,6 +409,28 @@ validates_attachment :avatar,
 
 `Paperclip::ContentTypeDetector` will attempt to match a file's extension to an
 inferred content_type, regardless of the actual contents of the file.
+
+### Duplicate error messages
+
+By default Paperclip will copy validation errors from the attribute to the base
+of your model. Depending on how you display your validation errors, this can lead
+to confusing duplicate errors (one on the attribute and another referring to the
+base model).
+
+You can override this behaviour with the `add_validation_errors_to` option. By
+default this is set to `:both` but can be set to either `:attribute` or `:base`.
+
+* `:both` creates errors on both the attribute and base model.
+* `:attribute` only creates an error on the attribute of the model.
+* `:base` only creates an error on the base model.
+
+You can set this option globally:
+
+`Paperclip.options[:add_validation_errors_to] = :attribute`
+
+or pass it in to an individual validation declaration:
+
+`validates_attachment :document, content_type: { content_type: "application/pdf" }, add_validation_errors_to: :attribute`
 
 ---
 

--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -98,7 +98,8 @@ module Paperclip
       swallow_stderr: true,
       use_exif_orientation: true,
       whiny: true,
-      is_windows: Gem.win_platform?
+      is_windows: Gem.win_platform?,
+      add_validation_errors_to: :both
     }
   end
 

--- a/lib/paperclip/validators.rb
+++ b/lib/paperclip/validators.rb
@@ -20,10 +20,10 @@ module Paperclip
     ::Paperclip::REQUIRED_VALIDATORS = [AttachmentFileNameValidator, AttachmentContentTypeValidator, AttachmentFileTypeIgnoranceValidator].freeze
 
     module ClassMethods
-      # This method is a shortcut to validator classes that is in
-      # "Attachment...Validator" format. It is almost the same thing as the
-      # +validates+ method that shipped with Rails, but this is customized to
-      # be using with attachment validators. This is helpful when you're using
+      # This method is a shortcut to the validator classes that are in
+      # "Attachment...Validator" format. It is almost the same as the
+      # +validates+ method that ships with Rails, but is customized for
+      # use with attachment validators. This is helpful when you're using
       # multiple attachment validators on a single attachment.
       #
       # Example of using the validator:

--- a/lib/paperclip/validators/attachment_content_type_validator.rb
+++ b/lib/paperclip/validators/attachment_content_type_validator.rb
@@ -3,6 +3,9 @@ module Paperclip
     class AttachmentContentTypeValidator < ActiveModel::EachValidator
       def initialize(options)
         options[:allow_nil] = true unless options.key?(:allow_nil)
+        unless options.key?(:add_validation_errors_to)
+          options[:add_validation_errors_to] = Paperclip.options[:add_validation_errors_to]
+        end
         super
       end
 
@@ -20,10 +23,13 @@ module Paperclip
         validate_whitelist(record, attribute, value)
         validate_blacklist(record, attribute, value)
 
-        if record.errors.include? attribute
+        if record.errors.include?(attribute) &&
+        [:both, :base].include?(options[:add_validation_errors_to])
           record.errors[attribute].each do |error|
             record.errors.add base_attribute, error
           end
+
+          record.errors.delete(attribute) if options[:add_validation_errors_to] == :base
         end
       end
 

--- a/lib/paperclip/validators/attachment_content_type_validator.rb
+++ b/lib/paperclip/validators/attachment_content_type_validator.rb
@@ -24,7 +24,8 @@ module Paperclip
         validate_blacklist(record, attribute, value)
 
         if record.errors.include?(attribute) &&
-        [:both, :base].include?(options[:add_validation_errors_to])
+            [:both, :base].include?(options[:add_validation_errors_to])
+
           record.errors[attribute].each do |error|
             record.errors.add base_attribute, error
           end

--- a/lib/paperclip/validators/attachment_file_name_validator.rb
+++ b/lib/paperclip/validators/attachment_file_name_validator.rb
@@ -24,7 +24,8 @@ module Paperclip
         validate_blacklist(record, attribute, value)
 
         if record.errors.include?(attribute) &&
-        [:both, :base].include?(options[:add_validation_errors_to])
+            [:both, :base].include?(options[:add_validation_errors_to])
+
           record.errors[attribute].each do |error|
             record.errors.add base_attribute, error
           end

--- a/lib/paperclip/validators/attachment_file_name_validator.rb
+++ b/lib/paperclip/validators/attachment_file_name_validator.rb
@@ -3,6 +3,9 @@ module Paperclip
     class AttachmentFileNameValidator < ActiveModel::EachValidator
       def initialize(options)
         options[:allow_nil] = true unless options.key?(:allow_nil)
+        unless options.key?(:add_validation_errors_to)
+          options[:add_validation_errors_to] = Paperclip.options[:add_validation_errors_to]
+        end
         super
       end
 
@@ -20,10 +23,13 @@ module Paperclip
         validate_whitelist(record, attribute, value)
         validate_blacklist(record, attribute, value)
 
-        if record.errors.include? attribute
+        if record.errors.include?(attribute) &&
+        [:both, :base].include?(options[:add_validation_errors_to])
           record.errors[attribute].each do |error|
             record.errors.add base_attribute, error
           end
+
+          record.errors.delete(attribute) if options[:add_validation_errors_to] == :base
         end
       end
 

--- a/lib/paperclip/validators/attachment_size_validator.rb
+++ b/lib/paperclip/validators/attachment_size_validator.rb
@@ -17,6 +17,18 @@ module Paperclip
       def validate_each(record, attr_name, value)
         base_attr_name = attr_name
         attr_name = "#{attr_name}_file_size".to_sym
+
+        error_attrs = []
+        case options[:add_validation_errors_to]
+        when :base
+          error_attrs << base_attr_name
+        when :attribute
+          error_attrs << attr_name
+        else
+          error_attrs << base_attr_name
+          error_attrs << attr_name
+        end
+
         value = record.send(:read_attribute_for_validation, attr_name)
 
         unless value.blank?
@@ -26,7 +38,7 @@ module Paperclip
 
             unless value.send(CHECKS[option], option_value)
               error_message_key = options[:in] ? :in_between : option
-              [attr_name, base_attr_name].each do |error_attr_name|
+              error_attrs.each do |error_attr_name|
                 record.errors.add(error_attr_name, error_message_key, filtered_options(value).merge(
                                                                         min: min_value_in_human_size(record),
                                                                         max: max_value_in_human_size(record),
@@ -55,6 +67,10 @@ module Paperclip
             options[:less_than_or_equal_to] = range
             options[:greater_than_or_equal_to] = range
           end
+        end
+
+        unless options.key?(:add_validation_errors_to)
+          options[:add_validation_errors_to] = Paperclip.options[:add_validation_errors_to]
         end
       end
 

--- a/spec/paperclip/validators/attachment_content_type_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_content_type_validator_spec.rb
@@ -67,6 +67,94 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
     end
   end
 
+  context "with add_validation_errors_to not set (implicitly :both)" do
+    it "adds error to both attribute and base" do
+      build_validator content_type: "image/png", allow_nil: false
+      @dummy.stubs(avatar_content_type: nil)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_content_type].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :attribute globally" do
+    before do
+      Paperclip.options[:add_validation_errors_to] = :attribute
+    end
+
+    after do
+      Paperclip.options[:add_validation_errors_to] = :both
+    end
+
+    it "only adds error to attribute not base" do
+      build_validator content_type: "image/png", allow_nil: false
+      @dummy.stubs(avatar_content_type: nil)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_content_type].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].blank?,
+        "Error added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :base globally" do
+    before do
+      Paperclip.options[:add_validation_errors_to] = :base
+    end
+
+    after do
+      Paperclip.options[:add_validation_errors_to] = :both
+    end
+
+    it "only adds error to base not attribute" do
+      build_validator content_type: "image/png", allow_nil: false
+      @dummy.stubs(avatar_content_type: nil)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+
+      assert @dummy.errors[:avatar_content_type].blank?,
+        "Error added to attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :attribute" do
+    it "only adds error to attribute not base" do
+      build_validator content_type: "image/png", allow_nil: false,
+        add_validation_errors_to: :attribute
+      @dummy.stubs(avatar_content_type: nil)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_content_type].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].blank?,
+        "Error added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :base" do
+    it "only adds error to base not attribute" do
+      build_validator content_type: "image/png", allow_nil: false,
+        add_validation_errors_to: :base
+      @dummy.stubs(avatar_content_type: nil)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+
+      assert @dummy.errors[:avatar_content_type].blank?,
+        "Error added to attribute"
+    end
+  end
+
   context "with a successful validation" do
     before do
       build_validator content_type: "image/png", allow_nil: false

--- a/spec/paperclip/validators/attachment_content_type_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_content_type_validator_spec.rb
@@ -74,10 +74,10 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_content_type].present?,
-        "Error not added to attribute"
+             "Error not added to attribute"
 
       assert @dummy.errors[:avatar].present?,
-        "Error not added to base attribute"
+             "Error not added to base attribute"
     end
   end
 
@@ -96,10 +96,10 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_content_type].present?,
-        "Error not added to attribute"
+             "Error not added to attribute"
 
       assert @dummy.errors[:avatar].blank?,
-        "Error added to base attribute"
+             "Error added to base attribute"
     end
   end
 
@@ -118,10 +118,10 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar].present?,
-        "Error not added to base attribute"
+             "Error not added to base attribute"
 
       assert @dummy.errors[:avatar_content_type].blank?,
-        "Error added to attribute"
+             "Error added to attribute"
     end
   end
 
@@ -133,10 +133,10 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_content_type].present?,
-        "Error not added to attribute"
+             "Error not added to attribute"
 
       assert @dummy.errors[:avatar].blank?,
-        "Error added to base attribute"
+             "Error added to base attribute"
     end
   end
 
@@ -148,10 +148,10 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar].present?,
-        "Error not added to base attribute"
+             "Error not added to base attribute"
 
       assert @dummy.errors[:avatar_content_type].blank?,
-        "Error added to attribute"
+             "Error added to attribute"
     end
   end
 

--- a/spec/paperclip/validators/attachment_content_type_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_content_type_validator_spec.rb
@@ -70,7 +70,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
   context "with add_validation_errors_to not set (implicitly :both)" do
     it "adds error to both attribute and base" do
       build_validator content_type: "image/png", allow_nil: false
-      @dummy.stubs(avatar_content_type: nil)
+      allow(@dummy).to receive_messages(avatar_content_type: nil)
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_content_type].present?,
@@ -92,7 +92,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
 
     it "only adds error to attribute not base" do
       build_validator content_type: "image/png", allow_nil: false
-      @dummy.stubs(avatar_content_type: nil)
+      allow(@dummy).to receive_messages(avatar_content_type: nil)
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_content_type].present?,
@@ -114,7 +114,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
 
     it "only adds error to base not attribute" do
       build_validator content_type: "image/png", allow_nil: false
-      @dummy.stubs(avatar_content_type: nil)
+      allow(@dummy).to receive_messages(avatar_content_type: nil)
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar].present?,
@@ -129,7 +129,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
     it "only adds error to attribute not base" do
       build_validator content_type: "image/png", allow_nil: false,
         add_validation_errors_to: :attribute
-      @dummy.stubs(avatar_content_type: nil)
+      allow(@dummy).to receive_messages(avatar_content_type: nil)
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_content_type].present?,
@@ -144,7 +144,7 @@ describe Paperclip::Validators::AttachmentContentTypeValidator do
     it "only adds error to base not attribute" do
       build_validator content_type: "image/png", allow_nil: false,
         add_validation_errors_to: :base
-      @dummy.stubs(avatar_content_type: nil)
+      allow(@dummy).to receive_messages(avatar_content_type: nil)
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar].present?,

--- a/spec/paperclip/validators/attachment_file_name_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_file_name_validator_spec.rb
@@ -29,6 +29,94 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
     end
   end
 
+  context "with add_validation_errors_to not set (implicitly :both)" do
+    it "adds error to both attribute and base" do
+      build_validator matches: /.*\.png$/, allow_nil: false
+      @dummy.stubs(avatar_file_name: "data.txt")
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_file_name].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :attribute globally" do
+    before do
+      Paperclip.options[:add_validation_errors_to] = :attribute
+    end
+
+    after do
+      Paperclip.options[:add_validation_errors_to] = :both
+    end
+
+    it "only adds error to attribute not base" do
+      build_validator matches: /.*\.png$/, allow_nil: false
+      @dummy.stubs(avatar_file_name: "data.txt")
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_file_name].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].blank?,
+        "Error added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :base globally" do
+    before do
+      Paperclip.options[:add_validation_errors_to] = :base
+    end
+
+    after do
+      Paperclip.options[:add_validation_errors_to] = :both
+    end
+
+    it "only adds error to base not attribute" do
+      build_validator matches: /.*\.png$/, allow_nil: false
+      @dummy.stubs(avatar_file_name: "data.txt")
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+
+      assert @dummy.errors[:avatar_file_name].blank?,
+        "Error added to attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :attribute" do
+    it "only adds error to attribute not base" do
+      build_validator matches: /.*\.png$/, allow_nil: false,
+        add_validation_errors_to: :attribute
+      @dummy.stubs(avatar_file_name: "data.txt")
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_file_name].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].blank?,
+        "Error added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :base" do
+    it "only adds error to base not attribute" do
+      build_validator matches: /.*\.png$/, allow_nil: false,
+        add_validation_errors_to: :base
+      @dummy.stubs(avatar_file_name: "data.txt")
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+
+      assert @dummy.errors[:avatar_file_name].blank?,
+        "Error added to attribute"
+    end
+  end
+
   it "does not add error to the base object with a successful validation" do
     build_validator matches: /.*\.png$/, allow_nil: false
     allow(@dummy).to receive_messages(avatar_file_name: "image.png")

--- a/spec/paperclip/validators/attachment_file_name_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_file_name_validator_spec.rb
@@ -36,10 +36,10 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_file_name].present?,
-        "Error not added to attribute"
+             "Error not added to attribute"
 
       assert @dummy.errors[:avatar].present?,
-        "Error not added to base attribute"
+             "Error not added to base attribute"
     end
   end
 
@@ -58,10 +58,10 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_file_name].present?,
-        "Error not added to attribute"
+             "Error not added to attribute"
 
       assert @dummy.errors[:avatar].blank?,
-        "Error added to base attribute"
+             "Error added to base attribute"
     end
   end
 
@@ -80,40 +80,42 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar].present?,
-        "Error not added to base attribute"
+             "Error not added to base attribute"
 
       assert @dummy.errors[:avatar_file_name].blank?,
-        "Error added to attribute"
+             "Error added to attribute"
     end
   end
 
   context "with add_validation_errors_to set to :attribute" do
     it "only adds error to attribute not base" do
       build_validator matches: /.*\.png$/, allow_nil: false,
-        add_validation_errors_to: :attribute
+                      add_validation_errors_to: :attribute
+
       allow(@dummy).to receive_messages(avatar_file_name: "data.txt")
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_file_name].present?,
-        "Error not added to attribute"
+             "Error not added to attribute"
 
       assert @dummy.errors[:avatar].blank?,
-        "Error added to base attribute"
+             "Error added to base attribute"
     end
   end
 
   context "with add_validation_errors_to set to :base" do
     it "only adds error to base not attribute" do
       build_validator matches: /.*\.png$/, allow_nil: false,
-        add_validation_errors_to: :base
+                      add_validation_errors_to: :base
+
       allow(@dummy).to receive_messages(avatar_file_name: "data.txt")
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar].present?,
-        "Error not added to base attribute"
+             "Error not added to base attribute"
 
       assert @dummy.errors[:avatar_file_name].blank?,
-        "Error added to attribute"
+             "Error added to attribute"
     end
   end
 

--- a/spec/paperclip/validators/attachment_file_name_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_file_name_validator_spec.rb
@@ -32,7 +32,7 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
   context "with add_validation_errors_to not set (implicitly :both)" do
     it "adds error to both attribute and base" do
       build_validator matches: /.*\.png$/, allow_nil: false
-      @dummy.stubs(avatar_file_name: "data.txt")
+      allow(@dummy).to receive_messages(avatar_file_name: "data.txt")
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_file_name].present?,
@@ -54,7 +54,7 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
 
     it "only adds error to attribute not base" do
       build_validator matches: /.*\.png$/, allow_nil: false
-      @dummy.stubs(avatar_file_name: "data.txt")
+      allow(@dummy).to receive_messages(avatar_file_name: "data.txt")
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_file_name].present?,
@@ -76,7 +76,7 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
 
     it "only adds error to base not attribute" do
       build_validator matches: /.*\.png$/, allow_nil: false
-      @dummy.stubs(avatar_file_name: "data.txt")
+      allow(@dummy).to receive_messages(avatar_file_name: "data.txt")
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar].present?,
@@ -91,7 +91,7 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
     it "only adds error to attribute not base" do
       build_validator matches: /.*\.png$/, allow_nil: false,
         add_validation_errors_to: :attribute
-      @dummy.stubs(avatar_file_name: "data.txt")
+      allow(@dummy).to receive_messages(avatar_file_name: "data.txt")
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_file_name].present?,
@@ -106,7 +106,7 @@ describe Paperclip::Validators::AttachmentFileNameValidator do
     it "only adds error to base not attribute" do
       build_validator matches: /.*\.png$/, allow_nil: false,
         add_validation_errors_to: :base
-      @dummy.stubs(avatar_file_name: "data.txt")
+      allow(@dummy).to receive_messages(avatar_file_name: "data.txt")
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar].present?,

--- a/spec/paperclip/validators/attachment_size_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_size_validator_spec.rb
@@ -205,6 +205,94 @@ describe Paperclip::Validators::AttachmentSizeValidator do
     end
   end
 
+  context "with add_validation_errors_to not set (implicitly :both)" do
+    it "adds error to both attribute and base" do
+      build_validator in: (5.kilobytes..10.kilobytes)
+      @dummy.stubs(:avatar_file_size).returns(11.kilobytes)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_file_size].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :attribute globally" do
+    before do
+      Paperclip.options[:add_validation_errors_to] = :attribute
+    end
+
+    after do
+      Paperclip.options[:add_validation_errors_to] = :both
+    end
+
+    it "only adds error to attribute not base" do
+      build_validator in: (5.kilobytes..10.kilobytes)
+      @dummy.stubs(:avatar_file_size).returns(11.kilobytes)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_file_size].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].blank?,
+        "Error added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :base globally" do
+    before do
+      Paperclip.options[:add_validation_errors_to] = :base
+    end
+
+    after do
+      Paperclip.options[:add_validation_errors_to] = :both
+    end
+
+    it "only adds error to base not attribute" do
+      build_validator in: (5.kilobytes..10.kilobytes)
+      @dummy.stubs(:avatar_file_size).returns(11.kilobytes)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+
+      assert @dummy.errors[:avatar_file_size].blank?,
+        "Error added to attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :attribute" do
+    it "only adds error to attribute not base" do
+      build_validator in: (5.kilobytes..10.kilobytes),
+        add_validation_errors_to: :attribute
+      @dummy.stubs(:avatar_file_size).returns(11.kilobytes)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar_file_size].present?,
+        "Error not added to attribute"
+
+      assert @dummy.errors[:avatar].blank?,
+        "Error added to base attribute"
+    end
+  end
+
+  context "with add_validation_errors_to set to :base" do
+    it "only adds error to base not attribute" do
+      build_validator in: (5.kilobytes..10.kilobytes),
+        add_validation_errors_to: :base
+      @dummy.stubs(:avatar_file_size).returns(11.kilobytes)
+      @validator.validate(@dummy)
+
+      assert @dummy.errors[:avatar].present?,
+        "Error not added to base attribute"
+
+      assert @dummy.errors[:avatar_file_size].blank?,
+        "Error added to attribute"
+    end
+  end
+
   context "using the helper" do
     before do
       Dummy.validates_attachment_size :avatar, in: (5.kilobytes..10.kilobytes)

--- a/spec/paperclip/validators/attachment_size_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_size_validator_spec.rb
@@ -212,10 +212,10 @@ describe Paperclip::Validators::AttachmentSizeValidator do
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_file_size].present?,
-        "Error not added to attribute"
+             "Error not added to attribute"
 
       assert @dummy.errors[:avatar].present?,
-        "Error not added to base attribute"
+             "Error not added to base attribute"
     end
   end
 
@@ -234,10 +234,10 @@ describe Paperclip::Validators::AttachmentSizeValidator do
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_file_size].present?,
-        "Error not added to attribute"
+             "Error not added to attribute"
 
       assert @dummy.errors[:avatar].blank?,
-        "Error added to base attribute"
+             "Error added to base attribute"
     end
   end
 
@@ -256,40 +256,42 @@ describe Paperclip::Validators::AttachmentSizeValidator do
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar].present?,
-        "Error not added to base attribute"
+             "Error not added to base attribute"
 
       assert @dummy.errors[:avatar_file_size].blank?,
-        "Error added to attribute"
+             "Error added to attribute"
     end
   end
 
   context "with add_validation_errors_to set to :attribute" do
     it "only adds error to attribute not base" do
       build_validator in: (5.kilobytes..10.kilobytes),
-        add_validation_errors_to: :attribute
+                      add_validation_errors_to: :attribute
+
       allow(@dummy).to receive(:avatar_file_size).and_return(11.kilobytes)
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_file_size].present?,
-        "Error not added to attribute"
+             "Error not added to attribute"
 
       assert @dummy.errors[:avatar].blank?,
-        "Error added to base attribute"
+             "Error added to base attribute"
     end
   end
 
   context "with add_validation_errors_to set to :base" do
     it "only adds error to base not attribute" do
       build_validator in: (5.kilobytes..10.kilobytes),
-        add_validation_errors_to: :base
+                      add_validation_errors_to: :base
+
       allow(@dummy).to receive(:avatar_file_size).and_return(11.kilobytes)
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar].present?,
-        "Error not added to base attribute"
+             "Error not added to base attribute"
 
       assert @dummy.errors[:avatar_file_size].blank?,
-        "Error added to attribute"
+             "Error added to attribute"
     end
   end
 

--- a/spec/paperclip/validators/attachment_size_validator_spec.rb
+++ b/spec/paperclip/validators/attachment_size_validator_spec.rb
@@ -208,7 +208,7 @@ describe Paperclip::Validators::AttachmentSizeValidator do
   context "with add_validation_errors_to not set (implicitly :both)" do
     it "adds error to both attribute and base" do
       build_validator in: (5.kilobytes..10.kilobytes)
-      @dummy.stubs(:avatar_file_size).returns(11.kilobytes)
+      allow(@dummy).to receive(:avatar_file_size).and_return(11.kilobytes)
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_file_size].present?,
@@ -230,7 +230,7 @@ describe Paperclip::Validators::AttachmentSizeValidator do
 
     it "only adds error to attribute not base" do
       build_validator in: (5.kilobytes..10.kilobytes)
-      @dummy.stubs(:avatar_file_size).returns(11.kilobytes)
+      allow(@dummy).to receive(:avatar_file_size).and_return(11.kilobytes)
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_file_size].present?,
@@ -252,7 +252,7 @@ describe Paperclip::Validators::AttachmentSizeValidator do
 
     it "only adds error to base not attribute" do
       build_validator in: (5.kilobytes..10.kilobytes)
-      @dummy.stubs(:avatar_file_size).returns(11.kilobytes)
+      allow(@dummy).to receive(:avatar_file_size).and_return(11.kilobytes)
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar].present?,
@@ -267,7 +267,7 @@ describe Paperclip::Validators::AttachmentSizeValidator do
     it "only adds error to attribute not base" do
       build_validator in: (5.kilobytes..10.kilobytes),
         add_validation_errors_to: :attribute
-      @dummy.stubs(:avatar_file_size).returns(11.kilobytes)
+      allow(@dummy).to receive(:avatar_file_size).and_return(11.kilobytes)
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar_file_size].present?,
@@ -282,7 +282,7 @@ describe Paperclip::Validators::AttachmentSizeValidator do
     it "only adds error to base not attribute" do
       build_validator in: (5.kilobytes..10.kilobytes),
         add_validation_errors_to: :base
-      @dummy.stubs(:avatar_file_size).returns(11.kilobytes)
+      allow(@dummy).to receive(:avatar_file_size).and_return(11.kilobytes)
       @validator.validate(@dummy)
 
       assert @dummy.errors[:avatar].present?,


### PR DESCRIPTION
This is an old PR that I had for Paperclip. See: https://github.com/thoughtbot/paperclip/pull/2347 for discussion.

I'd love to see it receiving the love it deserves :D

A couple of recent updates came through from my inclusion of recent Paperclip updates (README) but these can be reversed out by you if you like :)

___

Implicitly, errors are added to both base and the attribute, but we can now use `add_validation_errors_to` and set it to either `:attribute` or `:base`.
If it's not set, then errors would be added to both as below:
![Screenshot from 2020-08-04 11-20-53](https://user-images.githubusercontent.com/54796268/89385820-d4a79f80-d71d-11ea-8283-a67df990b82f.png)

When we set it to `:base`, it will add error to the base only as:
![Screenshot from 2020-08-04 11-20-16](https://user-images.githubusercontent.com/54796268/89385865-e8530600-d71d-11ea-85b7-566a0d25f7d4.png)

And when it's set to `:attribute`, it will add it to attribute as:
![Screenshot from 2020-08-04 11-19-58](https://user-images.githubusercontent.com/54796268/89385920-facd3f80-d71d-11ea-8bac-04bf12a571b6.png)
