### PR TITLE
Fix URI escape deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.4
   - 2.5
   - 2.6
+  - 2.7
 
 script: "bundle exec rake clean spec cucumber"
 

--- a/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
+++ b/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
@@ -9,7 +9,7 @@ module Paperclip
     REGEXP = /\Ahttps?:\/\//.freeze
 
     def initialize(target, options = {})
-      escaped = URI.escape(target)
+      escaped = URI.encode_www_form_component(target).gsub('+', '%20')
       super(URI(target == URI.unescape(target) ? escaped : target), options)
     end
   end

--- a/lib/paperclip/url_generator.rb
+++ b/lib/paperclip/url_generator.rb
@@ -65,7 +65,9 @@ module Paperclip
       if url.respond_to?(:escape)
         url.escape
       else
-        URI.escape(url).gsub(escape_regex) { |m| "%#{m.ord.to_s(16).upcase}" }
+        URI.encode_www_form_component(url)
+          .gsub('+', '%20')
+          .gsub(escape_regex) { |m| "%#{m.ord.to_s(16).upcase}" }
       end
     end
 


### PR DESCRIPTION
This PR will remove the deprecation warnings on Ruby 2.7