### PR TITLE
Use URI.open in ruby > 2.5

### DIFF
--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -50,10 +50,18 @@ module Paperclip
       "index.html"
     end
 
-    def download_content
-      options = { read_timeout: Paperclip.options[:read_timeout] }.compact
+    if RUBY_VERSION < '2.5'
+      def download_content
+        options = { read_timeout: Paperclip.options[:read_timeout] }.compact
 
-      self.open(@target, options)
+        open(@target, options)
+      end
+    else
+      def download_content
+        options = { read_timeout: Paperclip.options[:read_timeout] }.compact
+
+        URI.open(@target, options)
+      end
     end
 
     def copy_to_tempfile(src)

--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -54,7 +54,9 @@ module Paperclip
       def download_content
         options = { read_timeout: Paperclip.options[:read_timeout] }.compact
 
+        # rubocop:disable Security/Open
         open(@target, options)
+        # rubocop:enable Security/Open
       end
     else
       def download_content

--- a/spec/paperclip/io_adapters/uri_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/uri_adapter_spec.rb
@@ -193,17 +193,18 @@ describe Paperclip::UriAdapter do
 
   describe "#download_content" do
     before do
-      if RUBY_VERSION < '2.5'
-        allowed_mock = allow_any_instance_of(Paperclip::UriAdapter)
-      else
-        allowed_mock = allow(URI)
-      end
+      allowed_mock =
+        if RUBY_VERSION < '2.5'
+          allow_any_instance_of(Paperclip::UriAdapter)
+        else
+          allow(URI)
+        end
 
       allowed_mock.to receive(:open).and_return(@open_return)
 
       @uri = URI.parse("https://github.com/thoughtbot/paper:clip.jpg")
       @subject = Paperclip.io_adapters.for(@uri)
-      @uri_opener = RUBY_VERSION < '2.5' ? @subject : URI
+      @uri_opener = RUBY_VERSION < '2.5' ? @adapter : URI
     end
 
     after do
@@ -222,7 +223,8 @@ describe Paperclip::UriAdapter do
       end
 
       it "calls open with read_timeout option" do
-        expect(@uri_opener).to receive(:open).with(@uri, read_timeout: 120).at_least(1).times
+        expect(@uri_opener)
+          .to receive(:open).with(@uri, read_timeout: 120).at_least(1).times
       end
     end
   end

--- a/spec/paperclip/io_adapters/uri_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/uri_adapter_spec.rb
@@ -204,7 +204,7 @@ describe Paperclip::UriAdapter do
 
       @uri = URI.parse("https://github.com/thoughtbot/paper:clip.jpg")
       @subject = Paperclip.io_adapters.for(@uri)
-      @uri_opener = RUBY_VERSION < '2.5' ? @adapter : URI
+      @uri_opener = RUBY_VERSION < '2.5' ? @subject : URI
     end
 
     after do

--- a/spec/paperclip/io_adapters/uri_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/uri_adapter_spec.rb
@@ -193,9 +193,17 @@ describe Paperclip::UriAdapter do
 
   describe "#download_content" do
     before do
-      allow_any_instance_of(Paperclip::UriAdapter).to receive(:open).and_return(@open_return)
+      if RUBY_VERSION < '2.5'
+        allowed_mock = allow_any_instance_of(Paperclip::UriAdapter)
+      else
+        allowed_mock = allow(URI)
+      end
+
+      allowed_mock.to receive(:open).and_return(@open_return)
+
       @uri = URI.parse("https://github.com/thoughtbot/paper:clip.jpg")
       @subject = Paperclip.io_adapters.for(@uri)
+      @uri_opener = RUBY_VERSION < '2.5' ? @subject : URI
     end
 
     after do
@@ -204,7 +212,7 @@ describe Paperclip::UriAdapter do
 
     context "with default read_timeout" do
       it "calls open without options" do
-        expect(@subject).to receive(:open).with(@uri, {}).at_least(1).times
+        expect(@uri_opener).to receive(:open).with(@uri, {}).at_least(1).times
       end
     end
 
@@ -214,7 +222,7 @@ describe Paperclip::UriAdapter do
       end
 
       it "calls open with read_timeout option" do
-        expect(@subject).to receive(:open).with(@uri, read_timeout: 120).at_least(1).times
+        expect(@uri_opener).to receive(:open).with(@uri, read_timeout: 120).at_least(1).times
       end
     end
   end


### PR DESCRIPTION
Ruby 2.7 deprecates use of Kernel#open. Recommends URI.open.

Also, the fix done for 6.4.0 using self.open is broken in ruby 2.6. i.e., 6.4 version of the gem errs in 2.6.6.

This PR addresses issue #44 