### PR TITLE
pass options to `errors.add` as kwargs

### DIFF
--- a/lib/paperclip/validators/attachment_content_type_validator.rb
+++ b/lib/paperclip/validators/attachment_content_type_validator.rb
@@ -47,7 +47,7 @@ module Paperclip
       end
 
       def mark_invalid(record, attribute, types)
-        record.errors.add attribute, :invalid, options.merge(types: types.join(", "))
+        record.errors.add attribute, :invalid, **options.merge(types: types.join(", "))
       end
 
       def allowed_types

--- a/lib/paperclip/validators/attachment_file_name_validator.rb
+++ b/lib/paperclip/validators/attachment_file_name_validator.rb
@@ -43,7 +43,7 @@ module Paperclip
       end
 
       def mark_invalid(record, attribute, patterns)
-        record.errors.add attribute, :invalid, options.merge(names: patterns.join(", "))
+        record.errors.add attribute, :invalid, **options.merge(names: patterns.join(", "))
       end
 
       def allowed

--- a/lib/paperclip/validators/attachment_presence_validator.rb
+++ b/lib/paperclip/validators/attachment_presence_validator.rb
@@ -4,7 +4,7 @@ module Paperclip
   module Validators
     class AttachmentPresenceValidator < ActiveModel::EachValidator
       def validate_each(record, attribute, _value)
-        record.errors.add(attribute, :blank, options) if record.send("#{attribute}_file_name").blank?
+        record.errors.add(attribute, :blank, **options) if record.send("#{attribute}_file_name").blank?
       end
 
       def self.helper_method_name

--- a/lib/paperclip/validators/attachment_size_validator.rb
+++ b/lib/paperclip/validators/attachment_size_validator.rb
@@ -39,7 +39,7 @@ module Paperclip
             unless value.send(CHECKS[option], option_value)
               error_message_key = options[:in] ? :in_between : option
               error_attrs.each do |error_attr_name|
-                record.errors.add(error_attr_name, error_message_key, filtered_options(value).merge(
+                record.errors.add(error_attr_name, error_message_key, **filtered_options(value).merge(
                                                                         min: min_value_in_human_size(record),
                                                                         max: max_value_in_human_size(record),
                                                                         count: human_size(option_value)


### PR DESCRIPTION
Rails 6.1 expects the options to `ActiveModel::Errors#add` to be kwargs and Ruby 3.0 raises a `wrong number of arguments` error if we try to pass in the options as a hash.
Passing them in as kwargs should work with earlier versions or Rails, where the options param was a hash, as well.