### PR TITLE
Allow mimemagic 0.4.x

### DIFF
--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency("activemodel", ">= 4.2.0")
   s.add_dependency("activesupport", ">= 4.2.0")
   s.add_dependency("mime-types")
-  s.add_dependency("mimemagic", "~> 0.3.0")
+  s.add_dependency("mimemagic", "~> 0.3")
   s.add_dependency("terrapin", "~> 0.6.0")
 
   s.add_development_dependency("activerecord", ">= 4.2.0")


### PR DESCRIPTION
Several versions of the 0.3 series of mimemagic were yanked from
Rubygems this week. As a result many Rails apps will probably be
updating to 0.4.0 (or may be blocked from deploying due to relying on
yanked versions).

This change loosens the version dependency to allow updating mimemagic.