### PR TITLE
Replace mimemagic with marcel

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -25,5 +25,6 @@ end
 
 appraise "6.1" do
   gem "sqlite3", "~> 1.4", platforms: :ruby
+  gem "aruba", "~> 1.0", ">= 1.0.4"
   gem "rails", "~> 6.1", ">= 6.1.1"
 end

--- a/Appraisals
+++ b/Appraisals
@@ -25,6 +25,5 @@ end
 
 appraise "6.1" do
   gem "sqlite3", "~> 1.4", platforms: :ruby
-  gem "aruba", "~> 1.0", ">= 1.0.4"
   gem "rails", "~> 6.1", ">= 6.1.1"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,6 @@ group :development, :test do
   gem "bootsnap", require: false
   gem "builder"
   gem "listen", "~> 3.0.8"
-  gem "mime-types"
   gem "rspec"
   gem "rubocop", require: false
   gem "rubocop-rails"

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+Unreleased:
+
+* Replace `mimemagic` gem with `marcel` due to licensing issues. See also https://github.com/rails/marcel/pull/30 and https://weblog.rubyonrails.org/2021/3/26/marcel-upgrade-releases/
+
 6.1.0 (2018-07-27):
 
 * BUGFIX: Don't double-encode URLs (Roderick Monje).

--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
 Unreleased:
 
-* Replace `mimemagic` gem with `marcel` due to licensing issues. See also https://github.com/rails/marcel/pull/30 and https://weblog.rubyonrails.org/2021/3/26/marcel-upgrade-releases/
+* Replace `mimemagic` gem with `marcel` due to licensing issues. See https://github.com/kreeti/kt-paperclip/pull/54 for a list of known incompatibilities.
 
 6.1.0 (2018-07-27):
 

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -23,7 +23,7 @@ When /^I modify my attachment definition to:$/ do |definition|
 end
 
 When /^I upload the fixture "([^"]*)"$/ do |filename|
-  run_simple %(bundle exec rails runner "User.create!(:attachment => File.open('#{fixture_path(filename)}'))")
+  aruba_run_simple %(bundle exec rails runner "User.create!(:attachment => File.open('#{fixture_path(filename)}'))")
 end
 
 Then /^the attachment "([^"]*)" should have a dimension of (\d+x\d+)$/ do |filename, dimension|
@@ -106,5 +106,15 @@ Then /^I should not have attachment columns for "([^"]*)"$/ do |attachment_name|
     ]
 
     expect(columns).not_to include(*expect_columns)
+  end
+end
+
+# we have to support different versions of aruba, and this method was renamed for 1.0
+# https://github.com/cucumber/aruba/pull/438
+def aruba_run_simple(*args)
+  if respond_to?(:run_simple)
+    run_simple *args
+  elsif respond_to?(:run_command_and_stop)
+    run_command_and_stop *args
   end
 end

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -113,8 +113,8 @@ end
 # https://github.com/cucumber/aruba/pull/438
 def aruba_run_simple(*args)
   if respond_to?(:run_simple)
-    run_simple *args
+    run_simple(*args)
   elsif respond_to?(:run_command_and_stop)
-    run_command_and_stop *args
+    run_command_and_stop(*args)
   end
 end

--- a/gemfiles/4.2.gemfile
+++ b/gemfiles/4.2.gemfile
@@ -11,7 +11,6 @@ group :development, :test do
   gem "bootsnap", require: false
   gem "builder"
   gem "listen", "~> 3.0.8"
-  gem "mime-types"
   gem "rspec"
   gem "rubocop", require: false
   gem "rubocop-rails"

--- a/gemfiles/5.0.gemfile
+++ b/gemfiles/5.0.gemfile
@@ -11,7 +11,6 @@ group :development, :test do
   gem "bootsnap", require: false
   gem "builder"
   gem "listen", "~> 3.0.8"
-  gem "mime-types"
   gem "rspec"
   gem "rubocop", require: false
   gem "rubocop-rails"

--- a/gemfiles/5.1.gemfile
+++ b/gemfiles/5.1.gemfile
@@ -11,7 +11,6 @@ group :development, :test do
   gem "bootsnap", require: false
   gem "builder"
   gem "listen", "~> 3.0.8"
-  gem "mime-types"
   gem "rspec"
   gem "rubocop", require: false
   gem "rubocop-rails"

--- a/gemfiles/5.2.gemfile
+++ b/gemfiles/5.2.gemfile
@@ -11,7 +11,6 @@ group :development, :test do
   gem "bootsnap", require: false
   gem "builder"
   gem "listen", "~> 3.0.8"
-  gem "mime-types"
   gem "rspec"
   gem "rubocop", require: false
   gem "rubocop-rails"

--- a/gemfiles/6.0.gemfile
+++ b/gemfiles/6.0.gemfile
@@ -11,7 +11,6 @@ group :development, :test do
   gem "bootsnap", require: false
   gem "builder"
   gem "listen", "~> 3.0.8"
-  gem "mime-types"
   gem "rspec"
   gem "rubocop", require: false
   gem "rubocop-rails"

--- a/gemfiles/6.1.gemfile
+++ b/gemfiles/6.1.gemfile
@@ -4,6 +4,7 @@ source "https://rubygems.org"
 
 gem "pry"
 gem "sqlite3", "~> 1.4", platforms: :ruby
+gem "aruba", "~> 1.0", ">= 1.0.4"
 gem "rails", "~> 6.1", ">= 6.1.1"
 
 group :development, :test do

--- a/gemfiles/6.1.gemfile
+++ b/gemfiles/6.1.gemfile
@@ -4,7 +4,6 @@ source "https://rubygems.org"
 
 gem "pry"
 gem "sqlite3", "~> 1.4", platforms: :ruby
-gem "aruba", "~> 1.0", ">= 1.0.4"
 gem "rails", "~> 6.1", ">= 6.1.1"
 
 group :development, :test do
@@ -12,7 +11,6 @@ group :development, :test do
   gem "bootsnap", require: false
   gem "builder"
   gem "listen", "~> 3.0.8"
-  gem "mime-types"
   gem "rspec"
   gem "rubocop", require: false
   gem "rubocop-rails"

--- a/lib/paperclip.rb
+++ b/lib/paperclip.rb
@@ -64,8 +64,7 @@ rescue LoadError
   require "mime/types"
 end
 
-require "mimemagic"
-require "mimemagic/overlay"
+require "marcel"
 require "logger"
 require "terrapin"
 

--- a/lib/paperclip/content_type_detector.rb
+++ b/lib/paperclip/content_type_detector.rb
@@ -60,15 +60,15 @@ module Paperclip
     end
 
     def type_from_file_contents
-      type_from_mime_magic || type_from_file_command
+      type_from_marcel || type_from_file_command
     rescue Errno::ENOENT => e
       Paperclip.log("Error while determining content type: #{e}")
       SENSIBLE_DEFAULT
     end
 
-    def type_from_mime_magic
-      @type_from_mime_magic ||= File.open(@filepath) do |file|
-        MimeMagic.by_magic(file).try(:type)
+    def type_from_marcel
+      @type_from_marcel ||= File.open(@filepath) do |file|
+        Marcel::Magic.by_magic(file).try(:type)
       end
     end
 

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency("activemodel", ">= 4.2.0")
   s.add_dependency("activesupport", ">= 4.2.0")
   s.add_dependency("mime-types")
-  s.add_dependency("marcel", "~> 1.0.0")
+  s.add_dependency("marcel", "~> 1.0.1")
   s.add_dependency("terrapin", "~> 0.6.0")
 
   s.add_development_dependency("activerecord", ">= 4.2.0")

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -24,13 +24,12 @@ Gem::Specification.new do |s|
 
   s.add_dependency("activemodel", ">= 4.2.0")
   s.add_dependency("activesupport", ">= 4.2.0")
-  s.add_dependency("mime-types")
-  s.add_dependency("mimemagic", "~> 0.3.0")
+  s.add_dependency("marcel", "~> 1.0.0")
   s.add_dependency("terrapin", "~> 0.6.0")
 
   s.add_development_dependency("activerecord", ">= 4.2.0")
   s.add_development_dependency("appraisal")
-  s.add_development_dependency("aruba", "~> 0.9.0")
+  s.add_development_dependency("aruba", "~> 1.0.0")
   s.add_development_dependency("aws-sdk-s3")
   s.add_development_dependency("bundler")
   s.add_development_dependency("capybara")

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("activerecord", ">= 4.2.0")
   s.add_development_dependency("appraisal")
-  s.add_development_dependency("aruba", "~> 1.0.0")
+  s.add_development_dependency("aruba", "~> 0.9.0")
   s.add_development_dependency("aws-sdk-s3")
   s.add_development_dependency("bundler")
   s.add_development_dependency("capybara")

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("activemodel", ">= 4.2.0")
   s.add_dependency("activesupport", ">= 4.2.0")
+  s.add_dependency("mime-types")
   s.add_dependency("marcel", "~> 1.0.0")
   s.add_dependency("terrapin", "~> 0.6.0")
 

--- a/spec/paperclip/io_adapters/abstract_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/abstract_adapter_spec.rb
@@ -15,7 +15,7 @@ describe Paperclip::AbstractAdapter do
     before do
       allow(subject).to receive(:path).and_return("image.png")
       allow(Paperclip).to receive(:run).and_return("image/png\n")
-      allow_any_instance_of(Paperclip::ContentTypeDetector).to receive(:type_from_mime_magic).and_return("image/png")
+      allow_any_instance_of(Paperclip::ContentTypeDetector).to receive(:type_from_marcel).and_return("image/png")
     end
 
     it "returns the content type without newline" do

--- a/spec/paperclip/io_adapters/file_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/file_adapter_spec.rb
@@ -78,7 +78,7 @@ describe Paperclip::FileAdapter do
           allow(MIME::Types).to receive(:type_for).and_return([])
           allow(Paperclip).to receive(:run).and_return("application/vnd.ms-office\n")
           allow_any_instance_of(Paperclip::ContentTypeDetector).
-            to receive(:type_from_mime_magic).and_return("application/vnd.ms-office")
+            to receive(:type_from_marcel).and_return("application/vnd.ms-office")
 
           @subject = Paperclip.io_adapters.for(@file)
         end


### PR DESCRIPTION
Resolves https://github.com/kreeti/kt-paperclip/issues/53

See also https://github.com/rails/marcel/pull/30, https://weblog.rubyonrails.org/2021/3/26/marcel-upgrade-releases/,  https://github.com/carrierwaveuploader/carrierwave/pull/2551

### Known breaking changes

- Content type validators for MS office formats may need to be updated. See https://github.com/rails/marcel/blob/48644abd771ccaa25cdaad53c0ec02beb9ca73c9/lib/marcel/tables.rb for a list of supported types. For example, `validates_attachment :foo, content_type: { content_type: ["application/vnd.ms-excel"] }` may need to be changed to `validates_attachment :foo, content_type: { content_type: ["application/vnd.ms-excel", "application/x-tika-msoffice"] }`.
- Google sheets exports of office formats may not be recognized without additional configuration. Ensure you're using the latest version of `marcel` which includes https://github.com/rails/marcel/pull/36 