### PR TITLE
Fix Ruby 2.7 & Rails 6.1 deprecation messages

### DIFF
--- a/lib/paperclip/validators/attachment_file_name_validator.rb
+++ b/lib/paperclip/validators/attachment_file_name_validator.rb
@@ -27,7 +27,7 @@ module Paperclip
             [:both, :base].include?(options[:add_validation_errors_to])
 
           record.errors[attribute].each do |error|
-            record.errors.add base_attribute, error
+            record.errors.add(base_attribute, error)
           end
 
           record.errors.delete(attribute) if options[:add_validation_errors_to] == :base

--- a/spec/paperclip/validators_spec.rb
+++ b/spec/paperclip/validators_spec.rb
@@ -1,6 +1,10 @@
 require "spec_helper"
 
 describe Paperclip::Validators do
+  def error_attribute_names(error) # to support a range of rubies
+    error.try(:attribute_names) || error.keys
+  end
+
   context "using the helper" do
     before do
       rebuild_class
@@ -22,7 +26,7 @@ describe Paperclip::Validators do
     it "prevents you from attaching a file that violates that validation" do
       Dummy.class_eval { validate(:name) { raise "DO NOT RUN THIS" } }
       dummy = Dummy.new(avatar: File.new(fixture_file("12k.png")))
-      expect(dummy.errors.keys).to match_array [:avatar_content_type, :avatar, :avatar_file_size]
+      expect(error_attribute_names(dummy.errors)).to match_array [:avatar_content_type, :avatar, :avatar_file_size]
       assert_raises(RuntimeError) { dummy.valid? }
     end
   end
@@ -47,21 +51,21 @@ describe Paperclip::Validators do
     it "prevents you from attaching a file that violates all of these validations" do
       Dummy.class_eval { validate(:name) { raise "DO NOT RUN THIS" } }
       dummy = Dummy.new(avatar: File.new(fixture_file("spaced file.png")))
-      expect(dummy.errors.keys).to match_array [:avatar, :avatar_file_name]
+      expect(error_attribute_names(dummy.errors)).to match_array [:avatar, :avatar_file_name]
       assert_raises(RuntimeError) { dummy.valid? }
     end
 
     it "prevents you from attaching a file that violates only first of these validations" do
       Dummy.class_eval { validate(:name) { raise "DO NOT RUN THIS" } }
       dummy = Dummy.new(avatar: File.new(fixture_file("5k.png")))
-      expect(dummy.errors.keys).to match_array [:avatar, :avatar_file_name]
+      expect(error_attribute_names(dummy.errors)).to match_array [:avatar, :avatar_file_name]
       assert_raises(RuntimeError) { dummy.valid? }
     end
 
     it "prevents you from attaching a file that violates only second of these validations" do
       Dummy.class_eval { validate(:name) { raise "DO NOT RUN THIS" } }
       dummy = Dummy.new(avatar: File.new(fixture_file("spaced file.jpg")))
-      expect(dummy.errors.keys).to match_array [:avatar, :avatar_file_name]
+      expect(error_attribute_names(dummy.errors)).to match_array [:avatar, :avatar_file_name]
       assert_raises(RuntimeError) { dummy.valid? }
     end
 
@@ -88,7 +92,7 @@ describe Paperclip::Validators do
         end
       end
       dummy = Dummy.new(avatar: File.new(fixture_file("12k.png")))
-      expect(dummy.errors.keys).to match_array [:avatar_content_type, :avatar, :avatar_file_size]
+      expect(error_attribute_names(dummy.errors)).to match_array [:avatar_content_type, :avatar, :avatar_file_size]
     end
 
     it "does not validate attachment if title is not present" do
@@ -98,7 +102,7 @@ describe Paperclip::Validators do
         end
       end
       dummy = Dummy.new(avatar: File.new(fixture_file("12k.png")))
-      assert_equal [], dummy.errors.keys
+      assert_equal [], error_attribute_names(dummy.errors)
     end
   end
 

--- a/spec/paperclip/validators_spec.rb
+++ b/spec/paperclip/validators_spec.rb
@@ -1,7 +1,8 @@
 require "spec_helper"
 
 describe Paperclip::Validators do
-  def error_attribute_names(error) # to support a range of rubies
+  # required to support a range of rubies
+  def error_attribute_names(error)
     error.try(:attribute_names) || error.keys
   end
 
@@ -26,7 +27,9 @@ describe Paperclip::Validators do
     it "prevents you from attaching a file that violates that validation" do
       Dummy.class_eval { validate(:name) { raise "DO NOT RUN THIS" } }
       dummy = Dummy.new(avatar: File.new(fixture_file("12k.png")))
-      expect(error_attribute_names(dummy.errors)).to match_array [:avatar_content_type, :avatar, :avatar_file_size]
+      expect(error_attribute_names(dummy.errors)).to match_array(
+        %i[avatar_content_type avatar avatar_file_size]
+      )
       assert_raises(RuntimeError) { dummy.valid? }
     end
   end
@@ -51,21 +54,27 @@ describe Paperclip::Validators do
     it "prevents you from attaching a file that violates all of these validations" do
       Dummy.class_eval { validate(:name) { raise "DO NOT RUN THIS" } }
       dummy = Dummy.new(avatar: File.new(fixture_file("spaced file.png")))
-      expect(error_attribute_names(dummy.errors)).to match_array [:avatar, :avatar_file_name]
+      expect(error_attribute_names(dummy.errors)).to match_array(
+        %i[avatar avatar_file_name]
+      )
       assert_raises(RuntimeError) { dummy.valid? }
     end
 
     it "prevents you from attaching a file that violates only first of these validations" do
       Dummy.class_eval { validate(:name) { raise "DO NOT RUN THIS" } }
       dummy = Dummy.new(avatar: File.new(fixture_file("5k.png")))
-      expect(error_attribute_names(dummy.errors)).to match_array [:avatar, :avatar_file_name]
+      expect(error_attribute_names(dummy.errors)).to match_array(
+        %i[avatar avatar_file_name]
+      )
       assert_raises(RuntimeError) { dummy.valid? }
     end
 
     it "prevents you from attaching a file that violates only second of these validations" do
       Dummy.class_eval { validate(:name) { raise "DO NOT RUN THIS" } }
       dummy = Dummy.new(avatar: File.new(fixture_file("spaced file.jpg")))
-      expect(error_attribute_names(dummy.errors)).to match_array [:avatar, :avatar_file_name]
+      expect(error_attribute_names(dummy.errors)).to match_array(
+        %i[avatar avatar_file_name]
+      )
       assert_raises(RuntimeError) { dummy.valid? }
     end
 
@@ -92,7 +101,9 @@ describe Paperclip::Validators do
         end
       end
       dummy = Dummy.new(avatar: File.new(fixture_file("12k.png")))
-      expect(error_attribute_names(dummy.errors)).to match_array [:avatar_content_type, :avatar, :avatar_file_size]
+      expect(error_attribute_names(dummy.errors)).to match_array(
+        %i[avatar_content_type avatar avatar_file_size]
+      )
     end
 
     it "does not validate attachment if title is not present" do


### PR DESCRIPTION
These can be seen in https://travis-ci.com/github/kreeti/kt-paperclip/jobs/508937905

- ActiveModel::Errors#keys is deprecated and will be removed in Rails 6.2
- warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call