### PR TITLE
Issue delete calls only for unique file paths or objects

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+[UNRELEASED]
+Issue file delete only once per unique style when nullifying attachment or destroying an object. Avoids triggering a rate limit error on Google Cloud Storage.
+
 7.0.0 (2021-05-28)
 * Replace `mimemagic` gem with `marcel` due to licensing issues. See https://github.com/kreeti/kt-paperclip/pull/54 for details and limitations
 

--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -38,7 +38,7 @@ module Paperclip
     end
 
     attr_reader :name, :instance, :default_style, :convert_options, :queued_for_write, :whiny,
-                :options, :interpolator, :source_file_options
+                :options, :interpolator, :source_file_options, :queued_for_delete
     attr_accessor :post_processing
 
     # Creates an Attachment object. +name+ is the name of the attachment,

--- a/lib/paperclip/storage/filesystem.rb
+++ b/lib/paperclip/storage/filesystem.rb
@@ -57,7 +57,7 @@ module Paperclip
       end
 
       def flush_deletes #:nodoc:
-        @queued_for_delete.each do |path|
+        @queued_for_delete.uniq.each do |path|
           begin
             log("deleting #{path}")
             FileUtils.rm(path) if File.exist?(path)

--- a/lib/paperclip/storage/fog.rb
+++ b/lib/paperclip/storage/fog.rb
@@ -135,7 +135,7 @@ module Paperclip
       end
 
       def flush_deletes
-        @queued_for_delete.each do |path|
+        @queued_for_delete.uniq.each do |path|
           log("deleting #{path}")
           directory.files.new(key: path).destroy
         end

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -403,7 +403,7 @@ module Paperclip
       end
 
       def flush_deletes #:nodoc:
-        @queued_for_delete.each do |path|
+        @queued_for_delete.uniq.each do |path|
           begin
             log("deleting #{path}")
             s3_bucket.object(path.sub(%r{\A/}, "")).delete

--- a/spec/paperclip/storage/filesystem_spec.rb
+++ b/spec/paperclip/storage/filesystem_spec.rb
@@ -49,6 +49,29 @@ describe Paperclip::Storage::Filesystem do
         assert_equal @file.read, tempfile.read
         tempfile.close
       end
+
+      it "only issues a delete call once for each unique attachment style when nullifying attachment" do
+        @dummy.save
+        @dummy.avatar.clear(:thumbnail)
+        @dummy.avatar = nil
+        assert_equal 3, @dummy.avatar.queued_for_delete.size
+
+        expect(FileUtils).to receive(:rm).twice
+        @dummy.save
+
+        FileUtils.rm_rf("tmp")
+      end
+
+      it "only issues a delete call once for each unique attachment style when destroying model" do
+        @dummy.save
+        @dummy.avatar.clear(:thumbnail)
+        assert_equal 1, @dummy.avatar.queued_for_delete.size
+
+        expect(FileUtils).to receive(:rm).twice
+        @dummy.destroy
+
+        FileUtils.rm_rf("tmp")
+      end
     end
 
     context "with file that has space in file name" do

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -940,6 +940,19 @@ describe Paperclip::Storage::S3 do
         end
       end
 
+      context "and remove, calling S3 Object destroy once per unique style" do
+        before do
+          allow_any_instance_of(Aws::S3::Object).to receive(:exists?).and_return(true)
+          expect_any_instance_of(Aws::S3::Object).to receive(:delete).once
+          @dummy.avatar.clear(:original)
+          @dummy.destroy
+        end
+
+        it "succeeds" do
+          assert true
+        end
+      end
+
       context "that the file were missing" do
         before do
           allow_any_instance_of(Aws::S3::Object).to receive(:exists?).


### PR DESCRIPTION
Fixes an issue with Google Cloiud Storage issuing a rate limit error
due to their storage quotas for update operations being very limited.
See https://cloud.google.com/storage/quotas
Specifically:

>  There is a write limit to the same object name of once per second,
>  so rapid writes to the same object name won't scale.
>   For more information, see Object immutability.

Hat tip to Simon Rentzke for the fix originally.