### PR TITLE
Add rails 7 version specific fix for AttachmentSizeValidator

### DIFF
--- a/lib/paperclip/validators/attachment_size_validator.rb
+++ b/lib/paperclip/validators/attachment_size_validator.rb
@@ -35,8 +35,9 @@ module Paperclip
           options.slice(*AVAILABLE_CHECKS).each do |option, option_value|
             option_value = option_value.call(record) if option_value.is_a?(Proc)
             option_value = extract_option_value(option, option_value)
-
-            unless value.send(CHECKS[option], option_value)
+            operator = Rails::VERSION::MAJOR >= 7 ? COMPARE_CHECKS[option] : CHECKS[option]
+              
+            unless value.send(operator, option_value)
               error_message_key = options[:in] ? :in_between : option
               error_attrs.each do |error_attr_name|
                 record.errors.add(error_attr_name, error_message_key, **filtered_options(value).merge(


### PR DESCRIPTION
I compared the `COMPARE_CHECKS` (Rails 7) and `CHECKS` (Rails 6) - This can be replaced directly.