### PR TITLE
Improve content type detector

### DIFF
--- a/lib/paperclip/content_type_detector.rb
+++ b/lib/paperclip/content_type_detector.rb
@@ -31,7 +31,9 @@ module Paperclip
       elsif empty_file?
         EMPTY_TYPE
       else
-        calculated_type_matches.first || type_from_file_contents.first || SENSIBLE_DEFAULT
+        calculated_type_matches.first ||
+          type_from_file_contents.first ||
+          SENSIBLE_DEFAULT
       end.to_s
     end
 


### PR DESCRIPTION
Improve content type detector by getting all types back from Marcel and cross-referencing them with the possible types (file extension). This is an improvement because we don't want to trust Marcel to order their magic detection appropriately.

For example, I have a PDF that contains the string `wmv2` and Marcel is reporting that it's a `video/x-ms-wmv` file: https://github.com/rails/marcel/blob/main/lib/marcel/tables.rb#L2164. This is obviously wrong. If we were to use `Marcel::Magic.all_by_magic` then `application/pdf` is among the list of types returned. If Marcel considers it to be a possible PDF and the extension declares it as a pdf, let's just go with that.