### PR TITLE
removed S3 acls to stop errors from aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Paperclip
 =========
+Made changes to support S3 bucket policy
 
 We plan to support and maintain paperclip, as well as clean it up.
 

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -358,8 +358,7 @@ module Paperclip
           begin
             log("saving #{path(style)}")
             write_options = {
-              content_type: file.content_type,
-              acl: s3_permissions(style)
+              content_type: file.content_type
             }
 
             # add storage class for this style if defined


### PR DESCRIPTION
ACLs are no longer supported for S3 buckets in aws. It throws an error if this is not commented out