### PR TITLE
Backport Ruby 2.7 deprecation fixes to v4.x

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1048,7 +1048,7 @@ Lint/UselessAssignment:
   Description: Checks for useless assignment to a local variable.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars
   Enabled: true
-Lint/UselessComparison:
+Lint/BinaryOperatorWithIdenticalOperands:
   Description: Checks for comparison of something with itself.
   Enabled: true
 Lint/UselessElseWithoutRescue:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
   - 2.2.2
   - jruby-19mode
   - rbx-2
+  - 2.7
 
 script: "bundle exec rake clean spec cucumber"
 

--- a/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
+++ b/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
@@ -4,7 +4,8 @@ module Paperclip
     REGEXP = /\Ahttps?:\/\//
 
     def initialize(target)
-      super(URI(target))
+      escaped = Paperclip::UrlGenerator.escape(target)
+      super(URI(target == Paperclip::UrlGenerator.unescape(target) ? escaped : target))
     end
 
   end

--- a/lib/paperclip/url_generator.rb
+++ b/lib/paperclip/url_generator.rb
@@ -2,6 +2,13 @@ require 'uri'
 
 module Paperclip
   class UrlGenerator
+    class << self
+      def encoder
+        @encoder ||= URI::RFC2396_Parser.new
+      end
+      delegate :escape, :unescape, to: :encoder
+    end
+
     def initialize(attachment, attachment_options)
       @attachment = attachment
       @attachment_options = attachment_options
@@ -61,7 +68,7 @@ module Paperclip
       if url.respond_to?(:escape)
         url.escape
       else
-        URI.escape(url).gsub(escape_regex){|m| "%#{m.ord.to_s(16).upcase}" }
+        self.class.escape(url).gsub(escape_regex) { |m| "%#{m.ord.to_s(16).upcase}" }
       end
     end
 

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency('cocaine', '~> 0.5.5')
   s.add_dependency('mime-types')
   s.add_dependency('mimemagic', '~> 0.3.8')
+  s.add_dependency('bigdecimal', '1.3.5')
 
   s.add_development_dependency('activerecord', '>= 3.2.0', '< 5.0')
   s.add_development_dependency('shoulda')

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -20,13 +20,13 @@ Gem::Specification.new do |s|
   s.requirements << "ImageMagick"
   s.required_ruby_version = ">= 1.9.2"
 
-  s.add_dependency('activemodel', '>= 3.2.0')
-  s.add_dependency('activesupport', '>= 3.2.0')
+  s.add_dependency('activemodel', '>= 3.2.0', '< 5.0')
+  s.add_dependency('activesupport', '>= 3.2.0', '< 5.0')
   s.add_dependency('cocaine', '~> 0.5.5')
   s.add_dependency('mime-types')
   s.add_dependency('mimemagic', '~> 0.3.8')
 
-  s.add_development_dependency('activerecord', '>= 3.2.0')
+  s.add_development_dependency('activerecord', '>= 3.2.0', '< 5.0')
   s.add_development_dependency('shoulda')
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('appraisal')
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rake')
   s.add_development_dependency('fakeweb')
   s.add_development_dependency('railties')
-  s.add_development_dependency('actionmailer', '>= 3.2.0')
+  s.add_development_dependency('actionmailer', '>= 3.2.0', '< 5.0')
   s.add_development_dependency('generator_spec')
   s.add_development_dependency('timecop')
 end

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', '>= 3.2.0')
   s.add_dependency('cocaine', '~> 0.5.5')
   s.add_dependency('mime-types')
-  s.add_dependency('mimemagic', '0.3.0')
+  s.add_dependency('mimemagic', '~> 0.3.8')
 
   s.add_development_dependency('activerecord', '>= 3.2.0')
   s.add_development_dependency('shoulda')

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('appraisal')
   s.add_development_dependency('mocha')
   s.add_development_dependency('aws-sdk', '>= 1.5.7', "<= 2.0")
-  s.add_development_dependency('bourne')
+  s.add_development_dependency('bourne', '< 1.6')
   s.add_development_dependency('cucumber', '~> 1.3.18')
   s.add_development_dependency('aruba', '~> 0.9.0')
   s.add_development_dependency('nokogiri')

--- a/spec/paperclip/url_generator_spec.rb
+++ b/spec/paperclip/url_generator_spec.rb
@@ -184,6 +184,16 @@ describe Paperclip::UrlGenerator do
       "expected the interpolator to be passed #{expected.inspect} but it wasn't"
   end
 
+  it "doesn't emit deprecation warnings" do
+    expected = "the expected result"
+    mock_interpolator = MockInterpolator.new(result: expected)
+    options = { interpolator: mock_interpolator }
+    mock_attachment = MockAttachment.new(options)
+    url_generator = Paperclip::UrlGenerator.new(mock_attachment, options)
+
+    expect { url_generator.for(:style_name, escape: true) }.to_not(output(/URI\.(un)?escape is obsolete/).to_stderr)
+  end
+
   describe "should be able to escape (, ), [, and ]." do
     def generate(expected, updated_at=nil)
       mock_attachment = MockAttachment.new(updated_at: updated_at)

--- a/spec/support/model_reconstruction.rb
+++ b/spec/support/model_reconstruction.rb
@@ -16,15 +16,15 @@ module ModelReconstruction
 
   def reset_table table_name, &block
     block ||= lambda { |table| true }
-    ActiveRecord::Base.connection.create_table :dummies, {force: true}, &block
+    ActiveRecord::Base.connection.create_table :dummies, **{force: true}, &block
   end
 
   def modify_table table_name, &block
-    ActiveRecord::Base.connection.change_table :dummies, &block
+    ActiveRecord::Base.connection.create_table :dummies, **{force: true}, &block
   end
 
   def rebuild_model options = {}
-    ActiveRecord::Base.connection.create_table :dummies, force: true do |table|
+    ActiveRecord::Base.connection.create_table :dummies, **{force: true} do |table|
       table.column :title, :string
       table.column :other, :string
       table.column :avatar_file_name, :string


### PR DESCRIPTION
This PR aims at backporting deprecation fixes already present in [master](https://github.com/kreeti/kt-paperclip/pull/38) for Ruby > 2.7 to version 4 of KT-Paperclip.