### PR TITLE
Backport Ruby 2.7 deprecation fixes to v5.x

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1037,7 +1037,7 @@ Lint/UselessAssignment:
   Description: Checks for useless assignment to a local variable.
   StyleGuide: https://github.com/bbatsov/ruby-style-guide#underscore-unused-vars
   Enabled: true
-Lint/UselessComparison:
+Lint/BinaryOperatorWithIdenticalOperands:
   Description: Checks for comparison of something with itself.
   Enabled: true
 Lint/UselessElseWithoutRescue:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.2
   - 2.3
   - 2.4
+  - 2.7
 
 script: "bundle exec rake clean spec cucumber"
 

--- a/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
+++ b/lib/paperclip/io_adapters/http_url_proxy_adapter.rb
@@ -9,7 +9,8 @@ module Paperclip
     REGEXP = /\Ahttps?:\/\//
 
     def initialize(target, options = {})
-      super(URI(URI.escape(target)), options)
+      escaped = Paperclip::UrlGenerator.escape(target)
+      super(URI(target == Paperclip::UrlGenerator.unescape(target) ? escaped : target), options)
     end
   end
 end

--- a/lib/paperclip/io_adapters/uri_adapter.rb
+++ b/lib/paperclip/io_adapters/uri_adapter.rb
@@ -51,7 +51,7 @@ module Paperclip
     def download_content
       options = { read_timeout: Paperclip.options[:read_timeout] }.compact
 
-      open(@target, **options)
+      self.open(@target, options)
     end
 
     def copy_to_tempfile(src)

--- a/lib/paperclip/schema.rb
+++ b/lib/paperclip/schema.rb
@@ -24,7 +24,7 @@ module Paperclip
         attachment_names.each do |attachment_name|
           COLUMNS.each_pair do |column_name, column_type|
             column_options = options.merge(options[column_name.to_sym] || {})
-            add_column(table_name, "#{attachment_name}_#{column_name}", column_type, column_options)
+            add_column(table_name, "#{attachment_name}_#{column_name}", column_type, **column_options)
           end
         end
       end
@@ -51,7 +51,7 @@ module Paperclip
         attachment_names.each do |attachment_name|
           COLUMNS.each_pair do |column_name, column_type|
             column_options = options.merge(options[column_name.to_sym] || {})
-            column("#{attachment_name}_#{column_name}", column_type, column_options)
+            column("#{attachment_name}_#{column_name}", column_type, **column_options)
           end
         end
       end

--- a/lib/paperclip/url_generator.rb
+++ b/lib/paperclip/url_generator.rb
@@ -3,6 +3,13 @@ require 'active_support/core_ext/module/delegation'
 
 module Paperclip
   class UrlGenerator
+    class << self
+      def encoder
+        @encoder ||= URI::RFC2396_Parser.new
+      end
+      delegate :escape, :unescape, to: :encoder
+    end
+
     def initialize(attachment)
       @attachment = attachment
     end
@@ -65,7 +72,7 @@ module Paperclip
       if url.respond_to?(:escape)
         url.escape
       else
-        URI.escape(url).gsub(escape_regex){|m| "%#{m.ord.to_s(16).upcase}" }
+        self.class.escape(url).gsub(escape_regex){|m| "%#{m.ord.to_s(16).upcase}" }
       end
     end
 

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', '>= 4.2.0', '< 6.0')
   s.add_dependency('terrapin', '~> 0.6.0')
   s.add_dependency('mime-types')
-  s.add_dependency('mimemagic', '~> 0.3.0')
+  s.add_dependency('mimemagic', '~> 0.3.8')
 
   s.add_development_dependency('activerecord', '>= 4.2.0', '< 6.0')
   s.add_development_dependency('shoulda')

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -24,13 +24,13 @@ Gem::Specification.new do |s|
   s.requirements << "ImageMagick"
   s.required_ruby_version = ">= 2.1.0"
 
-  s.add_dependency('activemodel', '>= 4.2.0')
-  s.add_dependency('activesupport', '>= 4.2.0')
+  s.add_dependency('activemodel', '>= 4.2.0', '< 6.0')
+  s.add_dependency('activesupport', '>= 4.2.0', '< 6.0')
   s.add_dependency('terrapin', '~> 0.6.0')
   s.add_dependency('mime-types')
   s.add_dependency('mimemagic', '~> 0.3.0')
 
-  s.add_development_dependency('activerecord', '>= 4.2.0')
+  s.add_development_dependency('activerecord', '>= 4.2.0', '< 6.0')
   s.add_development_dependency('shoulda')
   s.add_development_dependency('rspec', '~> 3.0')
   s.add_development_dependency('appraisal')
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('launchy')
   s.add_development_dependency('rake')
   s.add_development_dependency('fakeweb')
-  s.add_development_dependency('railties')
+  s.add_development_dependency('railties', '>= 4.2.0', '< 6.0')
   s.add_development_dependency('generator_spec')
   s.add_development_dependency('timecop')
 end

--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('appraisal')
   s.add_development_dependency('mocha')
   s.add_development_dependency('aws-sdk', '>= 2.3.0', '< 3.0')
-  s.add_development_dependency('bourne')
+  s.add_development_dependency('bourne', '< 1.6')
   s.add_development_dependency('cucumber-rails')
   s.add_development_dependency('cucumber-expressions', '4.0.3') # TODO: investigate failures on 4.0.4
   s.add_development_dependency('aruba', '~> 0.9.0')

--- a/spec/paperclip/url_generator_spec.rb
+++ b/spec/paperclip/url_generator_spec.rb
@@ -195,6 +195,16 @@ describe Paperclip::UrlGenerator do
       "expected the interpolator to be passed #{expected.inspect} but it wasn't"
   end
 
+  it "doesn't emit deprecation warnings" do
+    expected = "the expected result"
+    mock_interpolator = MockInterpolator.new(result: expected)
+    options = { interpolator: mock_interpolator }
+    mock_attachment = MockAttachment.new(options)
+    url_generator = Paperclip::UrlGenerator.new(mock_attachment)
+
+    expect { url_generator.for(:style_name, escape: true) }.to_not(output(/URI\.(un)?escape is obsolete/).to_stderr)
+  end
+
   describe "should be able to escape (, ), [, and ]." do
     def generate(expected, updated_at=nil)
       mock_interpolator = MockInterpolator.new(result: expected)

--- a/spec/support/model_reconstruction.rb
+++ b/spec/support/model_reconstruction.rb
@@ -24,7 +24,7 @@ module ModelReconstruction
 
   def reset_table table_name, &block
     block ||= lambda { |table| true }
-    ActiveRecord::Base.connection.create_table :dummies, {force: true}, &block
+    ActiveRecord::Base.connection.create_table :dummies, **{force: true}, &block
   end
 
   def modify_table table_name, &block
@@ -32,7 +32,7 @@ module ModelReconstruction
   end
 
   def rebuild_model options = {}
-    ActiveRecord::Base.connection.create_table :dummies, force: true do |table|
+    ActiveRecord::Base.connection.create_table :dummies, **{force: true} do |table|
       table.column :title, :string
       table.column :other, :string
       table.column :avatar_file_name, :string


### PR DESCRIPTION
This PR aims at backporting deprecation fixes already present in https://github.com/kreeti/kt-paperclip/pull/38 for Ruby > 2.7 to version 5.x of KT-Paperclip.