### PR TITLE
Return the type at the end of the method call

### DIFF
--- a/lib/paperclip/content_type_detector.rb
+++ b/lib/paperclip/content_type_detector.rb
@@ -74,6 +74,7 @@ module Paperclip
       # Marcel::MineType returns 'application/octet-stream' if it can't find
       # a valid type.
       @type_from_marcel = nil if @type_from_marcel == SENSIBLE_DEFAULT
+      @type_from_marcel
     end
 
     def type_from_file_command


### PR DESCRIPTION
This is to fix a bug where if `@type_from_marcel` does not equal `SENSIBLE_DEFAULT`, `nil` is returned instead of the `@type_from_marcel` that was discovered on line 72:

```ruby
      @type_from_marcel = Marcel::MimeType.for Pathname.new(@filepath),
                                               name: @filepath
```