### PR TITLE
Unfreeze Paperclip::Schema::COLUMNS

### DIFF
--- a/lib/paperclip/schema.rb
+++ b/lib/paperclip/schema.rb
@@ -6,7 +6,7 @@ module Paperclip
     COLUMNS = { file_name: :string,
                 content_type: :string,
                 file_size: :bigint,
-                updated_at: :datetime }.freeze
+                updated_at: :datetime }
 
     def self.included(_base)
       ActiveRecord::ConnectionAdapters::Table.include TableDefinition


### PR DESCRIPTION
kt-paperclip freezes `Paperclip::Schema::COLUMNS` in #14.

We did the following in migration for preserving column type generated by old paperclip.
Freezing `Paperclip::Schema::COLUMNS` breaks compatibility with original paperclip.

```rb
  def change
    Paperclip::Schema::COLUMNS[:file_size] = :integer
    create_table :table_foo do |t|
      # ......
      t.attachment :file
      t.string :file_fingerprint, null: false
      t.timestamp :file_created_at, default: -> { "CURRENT_TIMESTAMP" }, null: false
      t.text :file_meta, null: false
    end
  ensure
    Paperclip::Schema::COLUMNS[:file_size] = :bigint
  end
```