### PR TITLE
stop initializing storage info on every attachemnt instance

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -10,30 +10,31 @@ module Paperclip
   class Attachment
     def self.default_options
       @default_options ||= {
-        convert_options:                  {},
-        default_style:                    :original,
-        default_url:                      "/:attachment/:style/missing.png",
-        escape_url:                       true,
-        restricted_characters:            /[&$+,\/:;=?@<>\[\]\{\}\|\\\^~%# ]/,
-        filename_cleaner:                 nil,
-        hash_data:                        ":class/:attachment/:id/:style/:updated_at",
-        hash_digest:                      "SHA1",
-        interpolator:                     Paperclip::Interpolations,
-        only_process:                     [],
-        path:                             ":rails_root/public:url",
-        preserve_files:                   false,
-        processors:                       [:thumbnail],
-        source_file_options:              {},
-        storage:                          :filesystem,
-        styles:                           {},
-        url:                              "/system/:class/:attachment/:id_partition/:style/:filename",
-        url_generator:                    Paperclip::UrlGenerator,
-        use_default_time_zone:            true,
-        use_timestamp:                    true,
-        whiny:                            Paperclip.options[:whiny] || Paperclip.options[:whiny_thumbnails],
-        validate_media_type:              true,
-        adapter_options:                  { hash_digest: Digest::MD5 },
-        check_validity_before_processing: true
+        convert_options:                             {},
+        default_style:                               :original,
+        default_url:                                 "/:attachment/:style/missing.png",
+        escape_url:                                  true,
+        restricted_characters:                       /[&$+,\/:;=?@<>\[\]\{\}\|\\\^~%# ]/,
+        filename_cleaner:                            nil,
+        hash_data:                                   ":class/:attachment/:id/:style/:updated_at",
+        hash_digest:                                 "SHA1",
+        interpolator:                                Paperclip::Interpolations,
+        only_process:                                [],
+        path:                                        ":rails_root/public:url",
+        preserve_files:                              false,
+        processors:                                  [:thumbnail],
+        source_file_options:                         {},
+        storage:                                     :filesystem,
+        styles:                                      {},
+        url:                                         "/system/:class/:attachment/:id_partition/:style/:filename",
+        url_generator:                               Paperclip::UrlGenerator,
+        use_default_time_zone:                       true,
+        use_timestamp:                               true,
+        whiny:                                       Paperclip.options[:whiny] || Paperclip.options[:whiny_thumbnails],
+        validate_media_type:                         true,
+        adapter_options:                             { hash_digest: Digest::MD5 },
+        check_validity_before_processing:            true,
+        enable_storage_preinitialization_experiment: false
       }
     end
 
@@ -87,7 +88,7 @@ module Paperclip
       @source_file_options   = options[:source_file_options]
       @whiny                 = options[:whiny]
 
-      initialize_storage
+      initialize_storage unless @options[:enable_storage_preinitialization_experiment] && @options[:storage].to_s.downcase == 's3'
     end
 
     # What gets called when you call instance.attachment = File. It clears

--- a/lib/paperclip/has_attached_file.rb
+++ b/lib/paperclip/has_attached_file.rb
@@ -39,12 +39,19 @@ module Paperclip
       name = @name
       options = @options
 
+      attachment_klass = if options[:enable_storage_preinitialization_experiment] && options[:storage].to_s.downcase == 's3'
+        require "paperclip/s3_attachment"
+        S3Attachment
+      else
+        Attachment
+      end
+
       @klass.send :define_method, @name do |*args|
         ivar = "@attachment_#{name}"
         attachment = instance_variable_get(ivar)
 
         if attachment.nil?
-          attachment = Attachment.new(name, self, options)
+          attachment = attachment_klass.new(name, self, options)
           instance_variable_set(ivar, attachment)
         end
 

--- a/lib/paperclip/s3_attachment.rb
+++ b/lib/paperclip/s3_attachment.rb
@@ -1,0 +1,36 @@
+module Paperclip
+  # The Attachment class manages the files for a given attachment. It saves
+  # when the model saves, deletes when the model is destroyed, and processes
+  # the file upon assignment.
+  class S3Attachment < Attachment
+    include Paperclip::Storage::S3
+
+    def initialize(name, instance, options = {})
+      super
+
+      @s3_options     = @options[:s3_options] || {}
+      @s3_permissions = set_permissions(@options[:s3_permissions])
+      @s3_protocol    = @options[:s3_protocol] || ""
+      @s3_metadata = @options[:s3_metadata] || {}
+      @s3_headers = {}
+      merge_s3_headers(@options[:s3_headers], @s3_headers, @s3_metadata)
+
+      @s3_storage_class = set_storage_class(@options[:s3_storage_class])
+
+      @s3_server_side_encryption = "AES256"
+      @s3_server_side_encryption = false if @options[:s3_server_side_encryption].blank?
+      @s3_server_side_encryption = @options[:s3_server_side_encryption] if @s3_server_side_encryption
+
+      unless @options[:url].to_s.match(/\A:s3.*url\z/) || @options[:url] == ":asset_host"
+        @options[:path] = path_option.gsub(/:url/, @options[:url]).sub(/\A:rails_root\/public\/system/, "")
+        @options[:url]  = ":s3_path_url"
+      end
+      @options[:url] = @options[:url].inspect if @options[:url].is_a?(Symbol)
+
+      @http_proxy = @options[:http_proxy] || nil
+
+      @use_accelerate_endpoint = @options[:use_accelerate_endpoint]
+    end
+
+  end
+end


### PR DESCRIPTION
Currently paperclip attachments initialize storage context on every instance by extending the corresponding storage modules as a last step of initialization.

https://github.com/kreeti/kt-paperclip/blob/master/lib/paperclip/attachment.rb#L425

However, this approach is not performant, especially when one needs to initialize 100s of attachment objects. One example,

- every user on our application has an avatar.
- We have a logic in which we need access all of the users'(within a customer) avatar urls. When we access the avatar urls for these users(let say 1000s of them) we are instantiating 1000s of attachment objects.

In our setup, initialize_storage phase is taking 800ms which is more than the half of total time spent.

With this PR. I aimed to simplify attachment initialization for users with s3 storage. I've also tried to hide this functionality behind `enable_storage_preinitialization_experiment` option to comply with backward compatibility.

Note: hoping to gather some benchmark information here.