### PR TITLE
Display attachment attrs when destroying the record

### DIFF
--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -71,7 +71,7 @@ module Paperclip
     # +url_generator+ - the object used to generate URLs, using the interpolator. Defaults to Paperclip::UrlGenerator
     # +escape_url+ - Perform URI escaping to URLs. Defaults to true
     # +hide_attrs_to_be_destroyed+ - whether attachment-related attributes should be displayed when destroying a record.
-    #                                Defaults to false.
+    #                                Defaults to true.
     def initialize(name, instance, options = {})
       @name              = name.to_sym
       @name_string       = name.to_s

--- a/lib/paperclip/attachment.rb
+++ b/lib/paperclip/attachment.rb
@@ -10,31 +10,31 @@ module Paperclip
   class Attachment
     def self.default_options
       @default_options ||= {
-        convert_options:                  {},
-        default_style:                    :original,
-        default_url:                      "/:attachment/:style/missing.png",
-        escape_url:                       true,
-        restricted_characters:            /[&$+,\/:;=?@<>\[\]\{\}\|\\\^~%# ]/,
-        filename_cleaner:                 nil,
-        hash_data:                        ":class/:attachment/:id/:style/:updated_at",
-        hash_digest:                      "SHA1",
-        interpolator:                     Paperclip::Interpolations,
-        only_process:                     [],
-        path:                             ":rails_root/public:url",
-        preserve_files:                   false,
-        processors:                       [:thumbnail],
-        source_file_options:              {},
-        storage:                          :filesystem,
-        styles:                           {},
-        url:                              "/system/:class/:attachment/:id_partition/:style/:filename",
-        url_generator:                    Paperclip::UrlGenerator,
-        use_default_time_zone:            true,
-        use_timestamp:                    true,
-        whiny:                            Paperclip.options[:whiny] || Paperclip.options[:whiny_thumbnails],
-        validate_media_type:              true,
-        adapter_options:                  { hash_digest: Digest::MD5 },
-        check_validity_before_processing: true,
-        hide_attrs_to_be_destroyed:       true
+        convert_options:                   {},
+        default_style:                     :original,
+        default_url:                       "/:attachment/:style/missing.png",
+        escape_url:                        true,
+        restricted_characters:             /[&$+,\/:;=?@<>\[\]\{\}\|\\\^~%# ]/,
+        filename_cleaner:                  nil,
+        hash_data:                         ":class/:attachment/:id/:style/:updated_at",
+        hash_digest:                       "SHA1",
+        interpolator:                      Paperclip::Interpolations,
+        only_process:                      [],
+        path:                              ":rails_root/public:url",
+        preserve_files:                    false,
+        processors:                        [:thumbnail],
+        source_file_options:               {},
+        storage:                           :filesystem,
+        styles:                            {},
+        url:                               "/system/:class/:attachment/:id_partition/:style/:filename",
+        url_generator:                     Paperclip::UrlGenerator,
+        use_default_time_zone:             true,
+        use_timestamp:                     true,
+        whiny:                             Paperclip.options[:whiny] || Paperclip.options[:whiny_thumbnails],
+        validate_media_type:               true,
+        adapter_options:                   { hash_digest: Digest::MD5 },
+        check_validity_before_processing:  true,
+        return_file_attributes_on_destroy: false
       }
     end
 
@@ -70,8 +70,8 @@ module Paperclip
     # +interpolator+ - the object used to interpolate filenames and URLs. Defaults to Paperclip::Interpolations
     # +url_generator+ - the object used to generate URLs, using the interpolator. Defaults to Paperclip::UrlGenerator
     # +escape_url+ - Perform URI escaping to URLs. Defaults to true
-    # +hide_attrs_to_be_destroyed+ - whether attachment-related attributes should be displayed when destroying a record.
-    #                                Defaults to true.
+    # +return_file_attributes_on_destroy+ - whether attachment-related attributes should be displayed when
+    #                                       destroying a record. Defaults to false.
     def initialize(name, instance, options = {})
       @name              = name.to_sym
       @name_string       = name.to_s
@@ -615,10 +615,10 @@ module Paperclip
       able_to_store_created_at? && !instance_read(:created_at)
     end
 
-    # Checks whether the option to hide attributes to be destroyed is disabled and whether a destroy callback has been
+    # Checks whether the option to show attributes to be destroyed is enabled and whether a destroy callback has been
     # invoked when deleting the entire record.
     def show_attrs_and_destroy_callback_triggered?
-      !@options[:hide_attrs_to_be_deleted] && instance.instance_variable_get(:@_destroy_callback_already_called)
+      @options[:return_file_attributes_on_destroy] && instance.instance_variable_get(:@_destroy_callback_already_called)
     end
 
     # Sets attachment-related attributes to `nil`.

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -1287,9 +1287,9 @@ describe Paperclip::Attachment do
                 @existing_names.each { |f| assert_file_not_exists(f) }
               end
 
-              context "when 'hide_attrs_to_be_destroyed' option is set to false" do
+              context "when 'return_file_attributes_on_destroy' option is set to true" do
                 before do
-                  @attachment.options[:hide_attrs_to_be_destroyed] = false
+                  @attachment.options[:return_file_attributes_on_destroy] = true
                 end
 
                 it "does not override attachment-related attributes and deletes the files" do

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -1267,7 +1267,7 @@ describe Paperclip::Attachment do
                 @existing_names.each { |f| assert_file_not_exists(f) }
               end
 
-              it "deletes the files when you call #delete" do
+              it "deletes the files when you call #destroy" do
                 expect(@attachment).to receive(:instance_write).with(:file_name, nil)
                 expect(@attachment).to receive(:instance_write).with(:content_type, nil)
                 expect(@attachment).to receive(:instance_write).with(:file_size, nil)
@@ -1275,6 +1275,32 @@ describe Paperclip::Attachment do
                 expect(@attachment).to receive(:instance_write).with(:updated_at, nil)
                 @attachment.destroy
                 @existing_names.each { |f| assert_file_not_exists(f) }
+              end
+
+              it "deletes the files when you destroy the model" do
+                expect(@attachment).to receive(:instance_write).with(:file_name, nil)
+                expect(@attachment).to receive(:instance_write).with(:content_type, nil)
+                expect(@attachment).to receive(:instance_write).with(:file_size, nil)
+                expect(@attachment).to receive(:instance_write).with(:fingerprint, nil)
+                expect(@attachment).to receive(:instance_write).with(:updated_at, nil)
+                @attachment.instance.destroy
+                @existing_names.each { |f| assert_file_not_exists(f) }
+              end
+
+              context "when 'hide_attrs_to_be_destroyed' option is set to false" do
+                before do
+                  @attachment.options[:hide_attrs_to_be_destroyed] = false
+                end
+
+                it "does not override attachment-related attributes and deletes the files" do
+                  expect(@attachment).not_to receive(:instance_write)
+                  expect(@attachment).not_to receive(:instance_write)
+                  expect(@attachment).not_to receive(:instance_write)
+                  expect(@attachment).not_to receive(:instance_write)
+                  expect(@attachment).not_to receive(:instance_write)
+                  @attachment.instance.destroy
+                  @existing_names.each { |f| assert_file_not_exists(f) }
+                end
               end
 
               context "when keeping old files" do
@@ -1304,7 +1330,7 @@ describe Paperclip::Attachment do
                   @existing_names.each { |f| assert_file_exists(f) }
                 end
 
-                it "keeps the files when you call #delete" do
+                it "keeps the files when you call #destroy" do
                   expect(@attachment).to receive(:instance_write).with(:file_name, nil)
                   expect(@attachment).to receive(:instance_write).with(:content_type, nil)
                   expect(@attachment).to receive(:instance_write).with(:file_size, nil)


### PR DESCRIPTION
Hey guys! I don't know if you still accept new features or just maintain the gem but there's behaviour that could be slightly modified. 

The default behaviour in AR is to return the entire object that was destroyed, see the screenshot below.

<img width="472" alt="Screenshot 2022-05-17 at 17 35 57" src="https://user-images.githubusercontent.com/4428862/168851702-9cd4c9ba-9e7b-4ad3-9740-19093c8c7ea6.png">

When a model includes Paperclip, unfortunately, its attributes are gone when the destroyed object is returned. It's a bit confusing, especially when tracking object changes. 

<img width="471" alt="Screenshot 2022-05-17 at 17 56 24" src="https://user-images.githubusercontent.com/4428862/168856293-5dc7832a-dd54-45e2-bfce-ccb1e7c7a4a2.png">

This PR introduces a way to keep the attributes being returned after destroying the record. By default, it doesn't change the original behaviour, but after setting `hide_attrs_to_be_destroyed` to `false` within the model, we can see what file data the record had. It works only for the `destroy` callback, so no changes when we update the file/assign `nil`.