### PR TITLE
Adjust version check to restore compatibility with non-rails projects

### DIFF
--- a/lib/paperclip/validators/attachment_size_validator.rb
+++ b/lib/paperclip/validators/attachment_size_validator.rb
@@ -35,7 +35,7 @@ module Paperclip
           options.slice(*AVAILABLE_CHECKS).each do |option, option_value|
             option_value = option_value.call(record) if option_value.is_a?(Proc)
             option_value = extract_option_value(option, option_value)
-            operator = Rails::VERSION::MAJOR >= 7 ? COMPARE_CHECKS[option] : CHECKS[option]
+            operator = ActiveRecord::VERSION::MAJOR >= 7 ? COMPARE_CHECKS[option] : CHECKS[option]
               
             unless value.send(operator, option_value)
               error_message_key = options[:in] ? :in_between : option


### PR DESCRIPTION
Since #73, the version of rails is checked, which breaks for non-rails projects because well, `Rails` isn't defined. What matters for this `COMPARE_CHECKS` vs `CHECKS` issue is more the version of `ActiveRecord` which is the lib providing it, so adjusting the code as such will restore compatibility with non-rails projects.