### PR TITLE
Use a thread local variable for recursion checking

### DIFF
--- a/lib/paperclip/interpolations.rb
+++ b/lib/paperclip/interpolations.rb
@@ -54,10 +54,14 @@ module Paperclip
     # Returns the interpolated URL. Will raise an error if the url itself
     # contains ":url" to prevent infinite recursion. This interpolation
     # is used in the default :path to ease default specifications.
-    RIGHT_HERE = "#{__FILE__.gsub(%r{\A\./}, '')}:#{__LINE__ + 3}"
     def url(attachment, style_name)
-      raise Errors::InfiniteInterpolationError if caller.any? { |b| b.index(RIGHT_HERE) }
+      if Thread.current.thread_variable_get(:kt_paperclip_no_recursion)
+        raise Errors::InfiniteInterpolationError
+      end
+      Thread.current.thread_variable_set(:kt_paperclip_no_recursion, true)
       attachment.url(style_name, timestamp: false, escape: false)
+    ensure
+      Thread.current.thread_variable_set(:kt_paperclip_no_recursion, false)
     end
 
     # Returns the timestamp as defined by the <attachment>_updated_at field


### PR DESCRIPTION
Checking the stack callstack is extremely expensive.  Use a thread local variable for detecting recursion and raising an exception.

Using the stacktrace means that JITs must exit because the stack must be reconstructed.  On top of that, the deeper the call stack, the more expensive constructing the call stack becomes.  This commit should provide the same safety, but be much cheaper than building a call stack.

For context, I was looking at some profiles of Mastodon, and I guess `url` is a popular (and expensive) method. 😅

Thanks!