### PR TITLE
Update tests for Ruby 3 compatibilty and fix YJIT read_attribute_for_validation 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ capybara*.html
 *SPIKE*
 *emfile.lock
 tags
+.idea

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -190,7 +190,7 @@ module Paperclip
           base_options = { expires_in: time }
           s3_object(style_name).presigned_url(
             :get,
-            base_options.merge(s3_url_options)
+            **base_options.merge(s3_url_options)
           ).to_s
         else
           url(style_name)
@@ -386,7 +386,7 @@ module Paperclip
             write_options[:metadata] = @s3_metadata unless @s3_metadata.empty?
             write_options.merge!(@s3_headers)
 
-            s3_object(style).upload_file(file.path, write_options)
+            s3_object(style).upload_file(file.path, **write_options)
           rescue ::Aws::S3::Errors::NoSuchBucket
             create_bucket
             retry

--- a/lib/paperclip/validators/attachment_content_type_validator.rb
+++ b/lib/paperclip/validators/attachment_content_type_validator.rb
@@ -16,7 +16,7 @@ module Paperclip
       def validate_each(record, attribute, value)
         base_attribute = attribute.to_sym
         attribute = "#{attribute}_content_type".to_sym
-        value = record.send :read_attribute_for_validation, attribute
+        value = record.read_attribute_for_validation(attribute)
 
         return if (value.nil? && options[:allow_nil]) || (value.blank? && options[:allow_blank])
 

--- a/lib/paperclip/validators/attachment_file_name_validator.rb
+++ b/lib/paperclip/validators/attachment_file_name_validator.rb
@@ -16,7 +16,7 @@ module Paperclip
       def validate_each(record, attribute, value)
         base_attribute = attribute.to_sym
         attribute = "#{attribute}_file_name".to_sym
-        value = record.send :read_attribute_for_validation, attribute
+        value = record.read_attribute_for_validation(attribute)
 
         return if (value.nil? && options[:allow_nil]) || (value.blank? && options[:allow_blank])
 

--- a/lib/paperclip/validators/attachment_size_validator.rb
+++ b/lib/paperclip/validators/attachment_size_validator.rb
@@ -29,7 +29,7 @@ module Paperclip
           error_attrs << attr_name
         end
 
-        value = record.send(:read_attribute_for_validation, attr_name)
+        value = record.read_attribute_for_validation(attr_name)
 
         unless value.blank?
           options.slice(*AVAILABLE_CHECKS).each do |option, option_value|

--- a/spec/paperclip/io_adapters/uri_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/uri_adapter_spec.rb
@@ -224,7 +224,7 @@ describe Paperclip::UriAdapter do
 
       it "calls open with read_timeout option" do
         expect(@uri_opener)
-          .to receive(:open).with(@uri, read_timeout: 120).at_least(1).times
+          .to receive(:open).with(@uri, { read_timeout: 120 }).at_least(1).times
       end
     end
   end

--- a/spec/paperclip/paperclip_spec.rb
+++ b/spec/paperclip/paperclip_spec.rb
@@ -63,7 +63,7 @@ describe Paperclip do
   context "Calling Paperclip.run with a logger" do
     it "passes the defined logger if :log_command is set" do
       Paperclip.options[:log_command] = true
-      expect(Terrapin::CommandLine).to receive(:new).with("convert", "stuff", logger: Paperclip.logger).and_return(double(run: nil))
+      expect(Terrapin::CommandLine).to receive(:new).with("convert", "stuff", { logger: Paperclip.logger }).and_return(double(run: nil))
       Paperclip.run("convert", "stuff")
     end
   end

--- a/spec/paperclip/schema_spec.rb
+++ b/spec/paperclip/schema_spec.rb
@@ -34,7 +34,7 @@ describe Paperclip::Schema do
         expect(columns).to include(["avatar_file_name", "varchar"])
         expect(columns).to include(["avatar_content_type", "varchar"])
         expect(columns).to include(["avatar_file_size", "bigint"])
-        expect(columns).to include(["avatar_updated_at", "datetime"])
+        expect(columns).to include(["avatar_updated_at", "datetime(6)"])
       end
 
       it "displays deprecation warning" do
@@ -59,7 +59,7 @@ describe Paperclip::Schema do
         expect(columns).to include(["avatar_file_name", "varchar"])
         expect(columns).to include(["avatar_content_type", "varchar"])
         expect(columns).to include(["avatar_file_size", "bigint"])
-        expect(columns).to include(["avatar_updated_at", "datetime"])
+        expect(columns).to include(["avatar_updated_at", "datetime(6)"])
       end
     end
 
@@ -98,7 +98,7 @@ describe Paperclip::Schema do
           expect(columns).to include(["avatar_file_name", "varchar"])
           expect(columns).to include(["avatar_content_type", "varchar"])
           expect(columns).to include(["avatar_file_size", "bigint"])
-          expect(columns).to include(["avatar_updated_at", "datetime"])
+          expect(columns).to include(["avatar_updated_at", "datetime(6)"])
         end
       end
 
@@ -128,11 +128,11 @@ describe Paperclip::Schema do
           expect(columns).to include(["avatar_file_name", "varchar"])
           expect(columns).to include(["avatar_content_type", "varchar"])
           expect(columns).to include(["avatar_file_size", "bigint"])
-          expect(columns).to include(["avatar_updated_at", "datetime"])
+          expect(columns).to include(["avatar_updated_at", "datetime(6)"])
           expect(columns).to include(["photo_file_name", "varchar"])
           expect(columns).to include(["photo_content_type", "varchar"])
           expect(columns).to include(["photo_file_size", "bigint"])
-          expect(columns).to include(["photo_updated_at", "datetime"])
+          expect(columns).to include(["photo_updated_at", "datetime(6)"])
         end
       end
 

--- a/spec/paperclip/schema_spec.rb
+++ b/spec/paperclip/schema_spec.rb
@@ -34,7 +34,7 @@ describe Paperclip::Schema do
         expect(columns).to include(["avatar_file_name", "varchar"])
         expect(columns).to include(["avatar_content_type", "varchar"])
         expect(columns).to include(["avatar_file_size", "bigint"])
-        expect(columns).to include(["avatar_updated_at", "datetime(6)"])
+        expect(columns).to include(["avatar_updated_at", "datetime"])
       end
 
       it "displays deprecation warning" do
@@ -59,7 +59,7 @@ describe Paperclip::Schema do
         expect(columns).to include(["avatar_file_name", "varchar"])
         expect(columns).to include(["avatar_content_type", "varchar"])
         expect(columns).to include(["avatar_file_size", "bigint"])
-        expect(columns).to include(["avatar_updated_at", "datetime(6)"])
+        expect(columns).to include(["avatar_updated_at", "datetime"])
       end
     end
 
@@ -98,7 +98,7 @@ describe Paperclip::Schema do
           expect(columns).to include(["avatar_file_name", "varchar"])
           expect(columns).to include(["avatar_content_type", "varchar"])
           expect(columns).to include(["avatar_file_size", "bigint"])
-          expect(columns).to include(["avatar_updated_at", "datetime(6)"])
+          expect(columns).to include(["avatar_updated_at", "datetime"])
         end
       end
 
@@ -128,11 +128,11 @@ describe Paperclip::Schema do
           expect(columns).to include(["avatar_file_name", "varchar"])
           expect(columns).to include(["avatar_content_type", "varchar"])
           expect(columns).to include(["avatar_file_size", "bigint"])
-          expect(columns).to include(["avatar_updated_at", "datetime(6)"])
+          expect(columns).to include(["avatar_updated_at", "datetime"])
           expect(columns).to include(["photo_file_name", "varchar"])
           expect(columns).to include(["photo_content_type", "varchar"])
           expect(columns).to include(["photo_file_size", "bigint"])
-          expect(columns).to include(["photo_updated_at", "datetime(6)"])
+          expect(columns).to include(["photo_updated_at", "datetime"])
         end
       end
 

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -395,12 +395,16 @@ describe Paperclip::Storage::S3 do
       allow(@dummy.avatar).to receive(:s3_object).with(:thumbnail).and_return(object)
 
       expect(object).to receive(:upload_file).
-        with(anything, content_type: "image/png",
-                       acl: :"public-read")
+        with(anything, {
+          content_type: "image/png",
+          acl: :"public-read"
+        })
       expect(object).to receive(:upload_file).
-        with(anything, content_type: "image/png",
-                       acl: :"public-read",
-                       cache_control: "max-age=31557600")
+        with(anything, {
+          content_type: "image/png",
+          acl: :"public-read",
+          cache_control: "max-age=31557600"
+        })
       @dummy.save
     end
 
@@ -445,12 +449,12 @@ describe Paperclip::Storage::S3 do
       it "uploads original" do
         expect(@object).to receive(:upload_file).with(
           anything,
-          content_type: "image/png",
+          { content_type: "image/png" },
         ).and_return(true)
         @dummy.avatar.reprocess!
         expect(@object).to receive(:upload_file).with(
           anything,
-          content_type: "image/png",
+          { content_type: "image/png" },
         ).and_return(true)
         @dummy.avatar.reprocess!
       end
@@ -458,7 +462,7 @@ describe Paperclip::Storage::S3 do
       it "doesn't upload original" do
         expect(@object).to receive(:upload_file).with(
           anything,
-          content_type: "image/png",
+          { content_type: "image/png" },
         ).and_return(true)
         @dummy.avatar.reprocess!
       end
@@ -500,14 +504,12 @@ describe Paperclip::Storage::S3 do
       it "uploads original" do
         expect(@object).to receive(:upload_file).with(
           anything,
-          content_type: "image/png",
-          acl: :"public-read"
+          { content_type: "image/png", acl: :"public-read" }
         ).and_return(true)
         @dummy.avatar.reprocess!
         expect(@object).to receive(:upload_file).with(
           anything,
-          content_type: "image/png",
-          acl: :"public-read"
+          { content_type: "image/png", acl: :"public-read" }
         ).and_return(true)
         @dummy.avatar.reprocess!
       end
@@ -515,8 +517,7 @@ describe Paperclip::Storage::S3 do
       it "doesn't upload original" do
         expect(@object).to receive(:upload_file).with(
           anything,
-          content_type: "image/png",
-          acl: :"public-read"
+          { content_type: "image/png", acl: :"public-read" }
         ).and_return(true)
         @dummy.avatar.reprocess!
       end
@@ -962,7 +963,7 @@ describe Paperclip::Storage::S3 do
           object = double
           allow(@dummy.avatar).to receive(:s3_object).and_return(object)
           expect(object).to receive(:upload_file).
-            with(anything, content_type: "image/png", acl: :"public-read")
+            with(anything, { content_type: "image/png", acl: :"public-read" })
           @dummy.save
         end
 
@@ -1299,7 +1300,7 @@ describe Paperclip::Storage::S3 do
               expected_options.merge!(storage_class: :reduced_redundancy) if style == :thumb
 
               expect(object).to receive(:upload_file).
-                with(anything, expected_options)
+                with(anything, **expected_options)
             end
             @dummy.save
           end
@@ -1342,9 +1343,11 @@ describe Paperclip::Storage::S3 do
               allow(@dummy.avatar).to receive(:s3_object).with(style).and_return(object)
 
               expect(object).to receive(:upload_file).
-                with(anything, content_type: "image/png",
-                               acl: :"public-read",
-                               storage_class: :reduced_redundancy)
+                with(anything, {
+                  content_type: "image/png",
+                  acl: :"public-read",
+                  storage_class: :reduced_redundancy
+                })
             end
             @dummy.save
           end
@@ -1387,7 +1390,7 @@ describe Paperclip::Storage::S3 do
             allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
             expect(object).to receive(:upload_file).
-              with(anything, content_type: "image/png", acl: :"public-read")
+              with(anything, { content_type: "image/png", acl: :"public-read" })
             @dummy.save
           end
 
@@ -1426,9 +1429,11 @@ describe Paperclip::Storage::S3 do
           allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
           expect(object).to receive(:upload_file).
-            with(anything, content_type: "image/png",
-                           acl: :"public-read",
-                           server_side_encryption: "AES256")
+            with(anything, {
+              content_type: "image/png",
+              acl: :"public-read",
+              server_side_encryption: "AES256"
+            })
           @dummy.save
         end
 
@@ -1613,7 +1618,7 @@ describe Paperclip::Storage::S3 do
             allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
             expect(object).to receive(:upload_file).
-              with(anything, content_type: "image/png", acl: :"public-read")
+              with(anything, { content_type: "image/png", acl: :"public-read" })
             @dummy.save
           end
 
@@ -1651,7 +1656,7 @@ describe Paperclip::Storage::S3 do
             allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
             expect(object).to receive(:upload_file).
-              with(anything, content_type: "image/png", acl: :private)
+              with(anything, { content_type: "image/png", acl: :private })
             @dummy.save
           end
 

--- a/spec/paperclip/thumbnail_spec.rb
+++ b/spec/paperclip/thumbnail_spec.rb
@@ -491,7 +491,9 @@ describe Paperclip::Thumbnail do
       tempfile = Tempfile.new("f")
       tempfile_additional_chars = tempfile.path.split("/")[-1].length + 15
       image_file = File.new(fixture_file("5k.png"), "rb")
-      @file = Tempfile.new("f" * (255 - tempfile_additional_chars))
+      filename = "f" * (255 - tempfile_additional_chars)
+      @file = Tempfile.new(filename)
+      @file.binmode
       @file.write(image_file.read)
       @file.rewind
     end


### PR DESCRIPTION
https://github.com/Shopify/yjit/issues/306

We we're running 3.2.0 Ruby with YJIT enabled. This change seemed to fix the issue described in the thread. It would probably be best to have 3.2.0 in the test matrix through which would require more work. 