### PR TITLE
Add exception message to avoid exposing class

### DIFF
--- a/lib/paperclip/geometry_detector_factory.rb
+++ b/lib/paperclip/geometry_detector_factory.rb
@@ -7,7 +7,7 @@ module Paperclip
 
     def make
       geometry = GeometryParser.new(geometry_string.strip).make
-      geometry || raise(Errors::NotIdentifiedByImageMagickError.new)
+      geometry || raise(Errors::NotIdentifiedByImageMagickError.new("Could not identify image size"))
     end
 
     private

--- a/spec/paperclip/geometry_detector_spec.rb
+++ b/spec/paperclip/geometry_detector_spec.rb
@@ -35,4 +35,13 @@ describe Paperclip::GeometryDetector do
       Paperclip.options[:use_exif_orientation] = true
     end
   end
+
+  it "raises an exception with a message when the file is not an image" do
+    file = fixture_file("text.txt")
+    factory = Paperclip::GeometryDetector.new(file)
+
+    expect do
+      factory.make
+    end.to raise_error(Paperclip::Errors::NotIdentifiedByImageMagickError, "Could not identify image size")
+  end
 end

--- a/spec/paperclip/geometry_spec.rb
+++ b/spec/paperclip/geometry_spec.rb
@@ -147,23 +147,35 @@ describe Paperclip::Geometry do
 
     it "does not generate from a bad file" do
       file = "/home/This File Does Not Exist.omg"
-      expect { @geo = Paperclip::Geometry.from_file(file) }.to raise_error(Paperclip::Errors::NotIdentifiedByImageMagickError)
+      expect do
+        @geo = Paperclip::Geometry.from_file(file)
+      end.to raise_error(Paperclip::Errors::NotIdentifiedByImageMagickError,
+                         "Could not identify image size")
     end
 
     it "does not generate from a blank filename" do
       file = ""
-      expect { @geo = Paperclip::Geometry.from_file(file) }.to raise_error(Paperclip::Errors::NotIdentifiedByImageMagickError)
+      expect do
+        @geo = Paperclip::Geometry.from_file(file)
+      end.to raise_error(Paperclip::Errors::NotIdentifiedByImageMagickError,
+                         "Cannot find the geometry of a file with a blank name")
     end
 
     it "does not generate from a nil file" do
       file = nil
-      expect { @geo = Paperclip::Geometry.from_file(file) }.to raise_error(Paperclip::Errors::NotIdentifiedByImageMagickError)
+      expect do
+        @geo = Paperclip::Geometry.from_file(file)
+      end.to raise_error(Paperclip::Errors::NotIdentifiedByImageMagickError,
+                         "Cannot find the geometry of a file with a blank name")
     end
 
     it "does not generate from a file with no path" do
       file = double("file", path: "")
       allow(file).to receive(:respond_to?).with(:path).and_return(true)
-      expect { @geo = Paperclip::Geometry.from_file(file) }.to raise_error(Paperclip::Errors::NotIdentifiedByImageMagickError)
+      expect do
+        @geo = Paperclip::Geometry.from_file(file)
+      end.to raise_error(Paperclip::Errors::NotIdentifiedByImageMagickError,
+                         "Cannot find the geometry of a file with a blank name")
     end
 
     it "lets us know when a command isn't found versus a processing error" do


### PR DESCRIPTION
This exception class is added to the model errors and shown to the end-user as is (`Errors::NotIdentifiedByImageMagickError`), because there is no message attached to it.

The exception is added as a processing error here:

https://github.com/kreeti/kt-paperclip/blob/11abf222dc31bff71160a1d138b445214f434b2b/lib/paperclip/attachment.rb#L537-L540

And the the processing errors are transferred to the model here:

https://github.com/kreeti/kt-paperclip/blob/91923a6ee1bd692696b51ea839f2f2578cb485b4/lib/paperclip/attachment.rb#L574-L578