### PR TITLE
Fix kwargs vs options hash for Ruby 3.0 compatibility

### DIFF
--- a/spec/paperclip/io_adapters/uri_adapter_spec.rb
+++ b/spec/paperclip/io_adapters/uri_adapter_spec.rb
@@ -224,7 +224,7 @@ describe Paperclip::UriAdapter do
 
       it "calls open with read_timeout option" do
         expect(@uri_opener)
-          .to receive(:open).with(@uri, read_timeout: 120).at_least(1).times
+          .to receive(:open).with(@uri, { read_timeout: 120 }).at_least(1).times
       end
     end
   end

--- a/spec/paperclip/paperclip_spec.rb
+++ b/spec/paperclip/paperclip_spec.rb
@@ -63,7 +63,7 @@ describe Paperclip do
   context "Calling Paperclip.run with a logger" do
     it "passes the defined logger if :log_command is set" do
       Paperclip.options[:log_command] = true
-      expect(Terrapin::CommandLine).to receive(:new).with("convert", "stuff", logger: Paperclip.logger).and_return(double(run: nil))
+      expect(Terrapin::CommandLine).to receive(:new).with("convert", "stuff", { logger: Paperclip.logger }).and_return(double(run: nil))
       Paperclip.run("convert", "stuff")
     end
   end

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -395,12 +395,22 @@ describe Paperclip::Storage::S3 do
       allow(@dummy.avatar).to receive(:s3_object).with(:thumbnail).and_return(object)
 
       expect(object).to receive(:upload_file).
-        with(anything, content_type: "image/png",
-                       acl: :"public-read")
+        with(
+          anything,
+          {
+            content_type: "image/png",
+            acl: :"public-read",
+          },
+        )
       expect(object).to receive(:upload_file).
-        with(anything, content_type: "image/png",
-                       acl: :"public-read",
-                       cache_control: "max-age=31557600")
+        with(
+          anything,
+          {
+            content_type: "image/png",
+            acl: :"public-read",
+            cache_control: "max-age=31557600",
+          },
+        )
       @dummy.save
     end
 
@@ -445,12 +455,12 @@ describe Paperclip::Storage::S3 do
       it "uploads original" do
         expect(@object).to receive(:upload_file).with(
           anything,
-          content_type: "image/png",
+          { content_type: "image/png" },
         ).and_return(true)
         @dummy.avatar.reprocess!
         expect(@object).to receive(:upload_file).with(
           anything,
-          content_type: "image/png",
+          { content_type: "image/png" },
         ).and_return(true)
         @dummy.avatar.reprocess!
       end
@@ -458,7 +468,7 @@ describe Paperclip::Storage::S3 do
       it "doesn't upload original" do
         expect(@object).to receive(:upload_file).with(
           anything,
-          content_type: "image/png",
+          { content_type: "image/png" },
         ).and_return(true)
         @dummy.avatar.reprocess!
       end
@@ -500,14 +510,18 @@ describe Paperclip::Storage::S3 do
       it "uploads original" do
         expect(@object).to receive(:upload_file).with(
           anything,
-          content_type: "image/png",
-          acl: :"public-read"
+          {
+            content_type: "image/png",
+            acl: :"public-read",
+          },
         ).and_return(true)
         @dummy.avatar.reprocess!
         expect(@object).to receive(:upload_file).with(
           anything,
-          content_type: "image/png",
-          acl: :"public-read"
+          {
+            content_type: "image/png",
+            acl: :"public-read",
+          },
         ).and_return(true)
         @dummy.avatar.reprocess!
       end
@@ -515,8 +529,10 @@ describe Paperclip::Storage::S3 do
       it "doesn't upload original" do
         expect(@object).to receive(:upload_file).with(
           anything,
-          content_type: "image/png",
-          acl: :"public-read"
+          {
+            content_type: "image/png",
+            acl: :"public-read",
+          },
         ).and_return(true)
         @dummy.avatar.reprocess!
       end
@@ -725,7 +741,7 @@ describe Paperclip::Storage::S3 do
         object = double
         allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
-        expect(object).to receive(:presigned_url).with(:get, expires_in: 3600)
+        expect(object).to receive(:presigned_url).with(:get, { expires_in: 3600 })
         @dummy.avatar.expiring_url
       end
     end
@@ -740,8 +756,13 @@ describe Paperclip::Storage::S3 do
         object = double
         allow(@dummy.avatar).to receive(:s3_object).and_return(object)
         expect(object).to receive(:presigned_url).
-          with(:get, expires_in: 3600,
-                     response_content_disposition: "inline")
+          with(
+            :get,
+            {
+              expires_in: 3600,
+              response_content_disposition: "inline",
+            },
+          )
         @dummy.avatar.expiring_url
       end
     end
@@ -763,7 +784,13 @@ describe Paperclip::Storage::S3 do
         object = double
         allow(@dummy.avatar).to receive(:s3_object).and_return(object)
         expect(object).to receive(:presigned_url).
-          with(:get, expires_in: 3600, response_content_type: "image/png")
+          with(
+            :get,
+            {
+              expires_in: 3600,
+              response_content_type: "image/png",
+            },
+          )
         @dummy.avatar.expiring_url
       end
     end
@@ -810,14 +837,14 @@ describe Paperclip::Storage::S3 do
     it "generates a url for the thumb" do
       object = double
       allow(@dummy.avatar).to receive(:s3_object).with(:thumb).and_return(object)
-      expect(object).to receive(:presigned_url).with(:get, expires_in: 1800)
+      expect(object).to receive(:presigned_url).with(:get, { expires_in: 1800 })
       @dummy.avatar.expiring_url(1800, :thumb)
     end
 
     it "generates a url for the default style" do
       object = double
       allow(@dummy.avatar).to receive(:s3_object).with(:original).and_return(object)
-      expect(object).to receive(:presigned_url).with(:get, expires_in: 1800)
+      expect(object).to receive(:presigned_url).with(:get, { expires_in: 1800 })
       @dummy.avatar.expiring_url(1800)
     end
   end
@@ -962,7 +989,7 @@ describe Paperclip::Storage::S3 do
           object = double
           allow(@dummy.avatar).to receive(:s3_object).and_return(object)
           expect(object).to receive(:upload_file).
-            with(anything, content_type: "image/png", acl: :"public-read")
+            with(anything, { content_type: "image/png", acl: :"public-read" })
           @dummy.save
         end
 
@@ -1122,10 +1149,14 @@ describe Paperclip::Storage::S3 do
           allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
           expect(object).to receive(:upload_file).
-            with(anything,
-                 content_type: "image/png",
-                 acl: :"public-read",
-                 cache_control: "max-age=31557600")
+            with(
+              anything,
+              {
+                content_type: "image/png",
+                acl: :"public-read",
+                cache_control: "max-age=31557600",
+              },
+            )
           @dummy.save
         end
 
@@ -1163,10 +1194,14 @@ describe Paperclip::Storage::S3 do
           allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
           expect(object).to receive(:upload_file).
-            with(anything,
+            with(
+              anything,
+              {
                  content_type: "image/png",
                  acl: :"public-read",
-                 metadata: { "color" => "red" })
+                 metadata: { "color" => "red" },
+              },
+            )
           @dummy.save
         end
 
@@ -1204,10 +1239,14 @@ describe Paperclip::Storage::S3 do
           allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
           expect(object).to receive(:upload_file).
-            with(anything,
+            with(
+              anything,
+              {
                  content_type: "image/png",
                  acl: :"public-read",
-                 metadata: { "color" => "red" })
+                 metadata: { "color" => "red" },
+              },
+            )
           @dummy.save
         end
 
@@ -1246,10 +1285,14 @@ describe Paperclip::Storage::S3 do
             allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
             expect(object).to receive(:upload_file).
-              with(anything,
+              with(
+                anything,
+                {
                    content_type: "image/png",
                    acl: :"public-read",
-                   storage_class: "reduced_redundancy")
+                   storage_class: "reduced_redundancy",
+                },
+              )
             @dummy.save
           end
 
@@ -1342,9 +1385,14 @@ describe Paperclip::Storage::S3 do
               allow(@dummy.avatar).to receive(:s3_object).with(style).and_return(object)
 
               expect(object).to receive(:upload_file).
-                with(anything, content_type: "image/png",
-                               acl: :"public-read",
-                               storage_class: :reduced_redundancy)
+                with(
+                  anything,
+                  {
+                    content_type: "image/png",
+                    acl: :"public-read",
+                    storage_class: :reduced_redundancy,
+                  },
+                )
             end
             @dummy.save
           end
@@ -1387,7 +1435,7 @@ describe Paperclip::Storage::S3 do
             allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
             expect(object).to receive(:upload_file).
-              with(anything, content_type: "image/png", acl: :"public-read")
+              with(anything, { content_type: "image/png", acl: :"public-read" })
             @dummy.save
           end
 
@@ -1426,9 +1474,14 @@ describe Paperclip::Storage::S3 do
           allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
           expect(object).to receive(:upload_file).
-            with(anything, content_type: "image/png",
-                           acl: :"public-read",
-                           server_side_encryption: "AES256")
+            with(
+              anything,
+              {
+                content_type: "image/png",
+                acl: :"public-read",
+                server_side_encryption: "AES256",
+              },
+            )
           @dummy.save
         end
 
@@ -1466,10 +1519,14 @@ describe Paperclip::Storage::S3 do
           allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
           expect(object).to receive(:upload_file).
-            with(anything,
-                 content_type: "image/png",
-                 acl: :"public-read",
-                 storage_class: :reduced_redundancy)
+            with(
+              anything,
+              {
+                content_type: "image/png",
+                acl: :"public-read",
+                storage_class: :reduced_redundancy,
+              },
+            )
           @dummy.save
         end
 
@@ -1613,7 +1670,7 @@ describe Paperclip::Storage::S3 do
             allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
             expect(object).to receive(:upload_file).
-              with(anything, content_type: "image/png", acl: :"public-read")
+              with(anything, { content_type: "image/png", acl: :"public-read" })
             @dummy.save
           end
 
@@ -1651,7 +1708,7 @@ describe Paperclip::Storage::S3 do
             allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
             expect(object).to receive(:upload_file).
-              with(anything, content_type: "image/png", acl: :private)
+              with(anything, { content_type: "image/png", acl: :private })
             @dummy.save
           end
 
@@ -1697,8 +1754,10 @@ describe Paperclip::Storage::S3 do
 
               expect(object).to receive(:upload_file).
                 with(anything,
-                     content_type: "image/png",
-                     acl: style == :thumb ? :public_read : :private)
+                     {
+                       content_type: "image/png",
+                       acl: style == :thumb ? :public_read : :private
+                     })
             end
             @dummy.save
           end
@@ -1767,10 +1826,14 @@ describe Paperclip::Storage::S3 do
             allow(@dummy.avatar).to receive(:s3_object).with(style).and_return(object)
 
             expect(object).to receive(:upload_file).
-              with(anything,
-                   content_type: "image/png",
-                   acl: :"public-read",
-                   content_disposition: 'attachment; filename="Custom Avatar Name.png"')
+              with(
+                anything,
+                {
+                  content_type: "image/png",
+                  acl: :"public-read",
+                  content_disposition: 'attachment; filename="Custom Avatar Name.png"',
+                },
+              )
           end
           @dummy.save
         end


### PR DESCRIPTION
This updates spec files for Ruby 3.0 compatibility where kwargs are expected in the tests, but an options hash is passed.

On the `master` branch:
```console
$ rbenv shell 3.0.6
$ BUNDLE_GEMFILE=gemfiles/6.1.gemfile bundle install
$ BUNDLE_GEMFILE=gemfiles/6.1.gemfile bundle exec rake spec
...

Failures:

  1) Paperclip::UriAdapter#download_content with custom read_timeout calls open with read_timeout option
     Failure/Error:
       expect(@uri_opener)
         .to receive(:open).with(@uri, read_timeout: 120).at_least(1).times

       URI received :open with unexpected arguments
         expected: (#<URI::HTTPS https://github.com/thoughtbot/paper:clip.jpg>, {:read_timeout=>120}) (keyword arguments)
              got: (#<URI::HTTPS https://github.com/thoughtbot/paper:clip.jpg>, {:read_timeout=>120}) (options hash)
     # ./spec/paperclip/io_adapters/uri_adapter_spec.rb:226:in `block (4 levels) in <top (required)>'

  2) Paperclip Calling Paperclip.run with a logger passes the defined logger if :log_command is set
     Failure/Error: Terrapin::CommandLine.new(cmd, arguments, local_options).run(interpolation_values)

       #<Terrapin::CommandLine (class)> received :new with unexpected arguments
         expected: ("convert", "stuff", {:logger=>#<Logger:0x000000013f6c23a8 @level=0, @progname=nil, @default_formatter=#<Logger::Formatter...ug.log>, @binmode=false, @mon_data=#<Monitor:0x000000013f6c2060>, @mon_data_
owner_object_id=54180>>}) (keyword arguments)
              got: ("convert", "stuff", {:logger=>#<Logger:0x000000013f6c23a8 @level=0, @progname=nil, @default_formatter=#<Logger::Formatter...ug.log>, @binmode=false, @mon_data=#<Monitor:0x000000013f6c2060>, @mon_data_
owner_object_id=54180>>}) (options hash)
     # ./lib/paperclip/helpers.rb:35:in `run'
     # ./spec/paperclip/paperclip_spec.rb:67:in `block (3 levels) in <top (required)>'
...
```