### PR TITLE
Mutate I18n.load_path only the first time Paperclip::Glue is included

### DIFF
--- a/lib/paperclip/glue.rb
+++ b/lib/paperclip/glue.rb
@@ -4,14 +4,15 @@ require "paperclip/schema"
 
 module Paperclip
   module Glue
+    LOCALE_PATHS = Dir.glob("#{File.dirname(__FILE__)}/locales/*.{rb,yml}")
+
     def self.included(base)
       base.extend ClassMethods
       base.send :include, Callbacks
       base.send :include, Validators
       base.send :include, Schema if defined? ActiveRecord::Base
 
-      locale_path = Dir.glob(File.dirname(__FILE__) + "/locales/*.{rb,yml}")
-      I18n.load_path += locale_path unless I18n.load_path.include?(locale_path)
+      I18n.load_path += LOCALE_PATHS unless (LOCALE_PATHS - I18n.load_path).empty?
     end
   end
 end

--- a/spec/paperclip/glue_spec.rb
+++ b/spec/paperclip/glue_spec.rb
@@ -39,4 +39,25 @@ describe Paperclip::Glue do
       Object.send :remove_const, "NonActiveRecordModel"
     end
   end
+
+  describe "when included" do
+    it "does not mutate I18n.load_path more than once" do
+      before_load_path = I18n.load_path
+      I18n.load_path = []
+
+      # expect twice because the load_path is reset after creating the classes
+      expect(I18n.config).to receive(:load_path=).and_call_original.twice
+
+      FirstModel = Class.new
+      FirstModel.include Paperclip::Glue
+
+      SecondModel = Class.new
+      SecondModel.include Paperclip::Glue
+
+      ThirdModel = Class.new
+      ThirdModel.include Paperclip::Glue
+
+      I18n.load_path = before_load_path
+    end
+  end
 end


### PR DESCRIPTION
Each time `Paperclip::Glue` is included, `I18n.load_paths += ...` is being executed.

This is happening because `locale_path` is an array of file paths which will not exist as a single item in `I18n.load_path`,
so `I18n.load_path.include?(locale_path)` always returns false