### PR TITLE
Support file extension names both as symbols and strings for :content_type_mappings

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,6 @@
 [UNRELEASED]
-Issue file delete only once per unique style when nullifying attachment or destroying an object. Avoids triggering a rate limit error on Google Cloud Storage.
+* Improvement: Support file extension names both as symbols and strings for :content_type_mappings
+* Issue file delete only once per unique style when nullifying attachment or destroying an object. Avoids triggering a rate limit error on Google Cloud Storage.
 
 7.0.0 (2021-05-28)
 * Replace `mimemagic` gem with `marcel` due to licensing issues. See https://github.com/kreeti/kt-paperclip/pull/54 for details and limitations

--- a/lib/paperclip/media_type_spoof_detector.rb
+++ b/lib/paperclip/media_type_spoof_detector.rb
@@ -82,7 +82,8 @@ module Paperclip
     end
 
     def mapped_content_type
-      Paperclip.options[:content_type_mappings][filename_extension]
+      content_type_mappings = Paperclip.options[:content_type_mappings]
+      content_type_mappings[filename_extension] || content_type_mappings[filename_extension.to_s]
     end
 
     def filename_extension

--- a/spec/paperclip/media_type_spoof_detector_spec.rb
+++ b/spec/paperclip/media_type_spoof_detector_spec.rb
@@ -32,12 +32,18 @@ describe Paperclip::MediaTypeSpoofDetector do
   end
 
   it "does not reject when the extension => content_type is in :content_type_mappings" do
+    file = Tempfile.open(["test", ".PEM"])
+    file.puts "Certificate!"
+    file.close
+
+    adapter = Paperclip.io_adapters.for(File.new(file.path))
+
     begin
       Paperclip.options[:content_type_mappings] = { pem: "text/plain" }
-      file = Tempfile.open(["test", ".PEM"])
-      file.puts "Certificate!"
-      file.close
-      adapter = Paperclip.io_adapters.for(File.new(file.path))
+      assert !Paperclip::MediaTypeSpoofDetector.using(adapter, adapter.original_filename, adapter.content_type).spoofed?
+
+      # As a string.
+      Paperclip.options[:content_type_mappings] = { "pem" => "text/plain" }
       assert !Paperclip::MediaTypeSpoofDetector.using(adapter, adapter.original_filename, adapter.content_type).spoofed?
     ensure
       Paperclip.options[:content_type_mappings] = {}


### PR DESCRIPTION
Closes #43.