### PR TITLE
support virtual_host in presigned_url when using s3_host_alias

### DIFF
--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -187,7 +187,10 @@ module Paperclip
 
       def expiring_url(time = 3600, style_name = default_style)
         if path(style_name)
-          base_options = { expires_in: time }
+          base_options = {
+            expires_in: time,
+            virtual_host:  @options[:url] == ":s3_alias_url" && @options[:s3_host_alias] != nil
+          }
           s3_object(style_name).presigned_url(
             :get,
             base_options.merge(s3_url_options)

--- a/spec/paperclip/storage/s3_spec.rb
+++ b/spec/paperclip/storage/s3_spec.rb
@@ -741,7 +741,7 @@ describe Paperclip::Storage::S3 do
         object = double
         allow(@dummy.avatar).to receive(:s3_object).and_return(object)
 
-        expect(object).to receive(:presigned_url).with(:get, { expires_in: 3600 })
+        expect(object).to receive(:presigned_url).with(:get, { expires_in: 3600, virtual_host: true })
         @dummy.avatar.expiring_url
       end
     end
@@ -761,6 +761,7 @@ describe Paperclip::Storage::S3 do
             {
               expires_in: 3600,
               response_content_disposition: "inline",
+              virtual_host: true
             },
           )
         @dummy.avatar.expiring_url
@@ -789,6 +790,7 @@ describe Paperclip::Storage::S3 do
             {
               expires_in: 3600,
               response_content_type: "image/png",
+              virtual_host: true
             },
           )
         @dummy.avatar.expiring_url
@@ -837,14 +839,14 @@ describe Paperclip::Storage::S3 do
     it "generates a url for the thumb" do
       object = double
       allow(@dummy.avatar).to receive(:s3_object).with(:thumb).and_return(object)
-      expect(object).to receive(:presigned_url).with(:get, { expires_in: 1800 })
+      expect(object).to receive(:presigned_url).with(:get, { expires_in: 1800, virtual_host: true })
       @dummy.avatar.expiring_url(1800, :thumb)
     end
 
     it "generates a url for the default style" do
       object = double
       allow(@dummy.avatar).to receive(:s3_object).with(:original).and_return(object)
-      expect(object).to receive(:presigned_url).with(:get, { expires_in: 1800 })
+      expect(object).to receive(:presigned_url).with(:get, { expires_in: 1800, virtual_host: true })
       @dummy.avatar.expiring_url(1800)
     end
   end


### PR DESCRIPTION
when using paperclip options: 
{ url: ":s3_alias_url" & "s3_host_alias": "bucket_alias.domain.com" }, 

make the presigned_url :
    https://bucket_alias.domain.com/file?X-Amz-Credential=

instead of:
    https://s3.amazonaws.com/bucket_alias.domain.com/file?X-Amz-Credential=