### PR TITLE
include migration statements on ActiveRecord::Migration

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 [UNRELEASED]
 * Improvement: Support file extension names both as symbols and strings for :content_type_mappings
 * Issue file delete only once per unique style when nullifying attachment or destroying an object. Avoids triggering a rate limit error on Google Cloud Storage.
+* Paperclip schema statements are consistent with ActiveRecord::Migration::Compatibility versioning. Old migrations containing Paperclip schema statements perform the same schema changes both before and after an ActiveRecord version upgrade.
 
 7.0.0 (2021-05-28)
 * Replace `mimemagic` gem with `marcel` due to licensing issues. See https://github.com/kreeti/kt-paperclip/pull/54 for details and limitations

--- a/lib/paperclip/schema.rb
+++ b/lib/paperclip/schema.rb
@@ -11,7 +11,7 @@ module Paperclip
     def self.included(_base)
       ActiveRecord::ConnectionAdapters::Table.include TableDefinition
       ActiveRecord::ConnectionAdapters::TableDefinition.include TableDefinition
-      ActiveRecord::ConnectionAdapters::AbstractAdapter.include Statements
+      ActiveRecord::Migration.include Statements
       ActiveRecord::Migration::CommandRecorder.include CommandRecorder
     end
 

--- a/spec/paperclip/attachment_spec.rb
+++ b/spec/paperclip/attachment_spec.rb
@@ -1333,7 +1333,7 @@ describe Paperclip::Attachment do
 
   context "An attachment with only a avatar_file_name column" do
     before do
-      ActiveRecord::Base.connection.create_table :dummies, force: true do |table|
+      ActiveRecord::Migration.create_table :dummies, force: true do |table|
         table.column :avatar_file_name, :string
       end
       rebuild_class
@@ -1359,7 +1359,7 @@ describe Paperclip::Attachment do
 
     context "and avatar_created_at column" do
       before do
-        ActiveRecord::Base.connection.add_column :dummies, :avatar_created_at, :timestamp
+        ActiveRecord::Migration.add_column :dummies, :avatar_created_at, :timestamp
         rebuild_class
         @dummy = Dummy.new
       end
@@ -1396,7 +1396,7 @@ describe Paperclip::Attachment do
 
     context "and avatar_updated_at column" do
       before do
-        ActiveRecord::Base.connection.add_column :dummies, :avatar_updated_at, :timestamp
+        ActiveRecord::Migration.add_column :dummies, :avatar_updated_at, :timestamp
         rebuild_class
         @dummy = Dummy.new
       end
@@ -1426,7 +1426,7 @@ describe Paperclip::Attachment do
 
     context "and avatar_content_type column" do
       before do
-        ActiveRecord::Base.connection.add_column :dummies, :avatar_content_type, :string
+        ActiveRecord::Migration.add_column :dummies, :avatar_content_type, :string
         rebuild_class
         @dummy = Dummy.new
       end
@@ -1443,7 +1443,7 @@ describe Paperclip::Attachment do
 
     context "and avatar_file_size column" do
       before do
-        ActiveRecord::Base.connection.add_column :dummies, :avatar_file_size, :bigint
+        ActiveRecord::Migration.add_column :dummies, :avatar_file_size, :bigint
         rebuild_class
         @dummy = Dummy.new
       end
@@ -1467,7 +1467,7 @@ describe Paperclip::Attachment do
 
     context "and avatar_fingerprint column" do
       before do
-        ActiveRecord::Base.connection.add_column :dummies, :avatar_fingerprint, :string
+        ActiveRecord::Migration.add_column :dummies, :avatar_fingerprint, :string
         rebuild_class
         @dummy = Dummy.new
       end

--- a/spec/paperclip/paperclip_missing_attachment_styles_spec.rb
+++ b/spec/paperclip/paperclip_missing_attachment_styles_spec.rb
@@ -49,7 +49,7 @@ describe "Missing Attachment Styles" do
     expected_hash = { Dummy: { avatar: [:export, :thumb] } }
     assert_equal expected_hash, Paperclip.missing_attachments_styles
 
-    ActiveRecord::Base.connection.create_table :books, force: true
+    ActiveRecord::Migration.create_table :books, force: true
     class ::Book < ActiveRecord::Base
       has_attached_file :cover, styles: { small: "x100", large: "1000x1000>" }
       has_attached_file :sample, styles: { thumb: "x100" }

--- a/spec/paperclip/schema_spec.rb
+++ b/spec/paperclip/schema_spec.rb
@@ -11,7 +11,7 @@ describe Paperclip::Schema do
 
   after do
     begin
-      Dummy.connection.drop_table :dummies
+      ActiveRecord::Migration.drop_table :dummies
     rescue StandardError
       nil
     end
@@ -23,7 +23,7 @@ describe Paperclip::Schema do
         ActiveSupport::Deprecation.silenced = false
       end
       it "creates attachment columns" do
-        Dummy.connection.create_table :dummies, force: true do |t|
+        ActiveRecord::Migration.create_table :dummies, force: true do |t|
           ActiveSupport::Deprecation.silence do
             t.has_attached_file :avatar
           end
@@ -38,7 +38,7 @@ describe Paperclip::Schema do
       end
 
       it "displays deprecation warning" do
-        Dummy.connection.create_table :dummies, force: true do |t|
+        ActiveRecord::Migration.create_table :dummies, force: true do |t|
           assert_deprecated do
             t.has_attached_file :avatar
           end
@@ -48,7 +48,7 @@ describe Paperclip::Schema do
 
     context "using #attachment" do
       before do
-        Dummy.connection.create_table :dummies, force: true do |t|
+        ActiveRecord::Migration.create_table :dummies, force: true do |t|
           t.attachment :avatar
         end
       end
@@ -65,7 +65,7 @@ describe Paperclip::Schema do
 
     context "using #attachment with options" do
       before do
-        Dummy.connection.create_table :dummies, force: true do |t|
+        ActiveRecord::Migration.create_table :dummies, force: true do |t|
           t.attachment :avatar, default: 1, file_name: { default: "default" }
         end
       end
@@ -83,13 +83,13 @@ describe Paperclip::Schema do
 
   context "within schema statement" do
     before do
-      Dummy.connection.create_table :dummies, force: true
+      ActiveRecord::Migration.create_table :dummies, force: true
     end
 
     context "migrating up" do
       context "with single attachment" do
         before do
-          Dummy.connection.add_attachment :dummies, :avatar
+          ActiveRecord::Migration.add_attachment :dummies, :avatar
         end
 
         it "creates attachment columns" do
@@ -104,7 +104,7 @@ describe Paperclip::Schema do
 
       context "with single attachment and options" do
         before do
-          Dummy.connection.add_attachment :dummies, :avatar, default: "1", file_name: { default: "default" }
+          ActiveRecord::Migration.add_attachment :dummies, :avatar, default: "1", file_name: { default: "default" }
         end
 
         it "sets defaults on columns" do
@@ -119,7 +119,7 @@ describe Paperclip::Schema do
 
       context "with multiple attachments" do
         before do
-          Dummy.connection.add_attachment :dummies, :avatar, :photo
+          ActiveRecord::Migration.add_attachment :dummies, :avatar, :photo
         end
 
         it "creates attachment columns" do
@@ -138,7 +138,7 @@ describe Paperclip::Schema do
 
       context "with multiple attachments and options" do
         before do
-          Dummy.connection.add_attachment :dummies, :avatar, :photo, default: "1", file_name: { default: "default" }
+          ActiveRecord::Migration.add_attachment :dummies, :avatar, :photo, default: "1", file_name: { default: "default" }
         end
 
         it "sets defaults on columns" do
@@ -157,7 +157,7 @@ describe Paperclip::Schema do
       context "with no attachment" do
         it "raises an error" do
           assert_raises ArgumentError do
-            Dummy.connection.add_attachment :dummies
+            ActiveRecord::Migration.add_attachment :dummies
           end
         end
       end
@@ -165,7 +165,7 @@ describe Paperclip::Schema do
 
     context "migrating down" do
       before do
-        Dummy.connection.change_table :dummies do |t|
+        ActiveRecord::Migration.change_table :dummies do |t|
           t.column :avatar_file_name, :string
           t.column :avatar_content_type, :string
           t.column :avatar_file_size, :bigint
@@ -179,7 +179,7 @@ describe Paperclip::Schema do
         end
         it "removes the attachment columns" do
           ActiveSupport::Deprecation.silence do
-            Dummy.connection.drop_attached_file :dummies, :avatar
+            ActiveRecord::Migration.drop_attached_file :dummies, :avatar
           end
 
           columns = Dummy.columns.map { |column| [column.name, column.sql_type] }
@@ -192,7 +192,7 @@ describe Paperclip::Schema do
 
         it "displays a deprecation warning" do
           assert_deprecated do
-            Dummy.connection.drop_attached_file :dummies, :avatar
+            ActiveRecord::Migration.drop_attached_file :dummies, :avatar
           end
         end
       end
@@ -200,7 +200,7 @@ describe Paperclip::Schema do
       context "using #remove_attachment" do
         context "with single attachment" do
           before do
-            Dummy.connection.remove_attachment :dummies, :avatar
+            ActiveRecord::Migration.remove_attachment :dummies, :avatar
           end
 
           it "removes the attachment columns" do
@@ -215,14 +215,14 @@ describe Paperclip::Schema do
 
         context "with multiple attachments" do
           before do
-            Dummy.connection.change_table :dummies do |t|
+            ActiveRecord::Migration.change_table :dummies do |t|
               t.column :photo_file_name, :string
               t.column :photo_content_type, :string
               t.column :photo_file_size, :bigint
               t.column :photo_updated_at, :datetime
             end
 
-            Dummy.connection.remove_attachment :dummies, :avatar, :photo
+            ActiveRecord::Migration.remove_attachment :dummies, :avatar, :photo
           end
 
           it "removes the attachment columns" do
@@ -242,7 +242,7 @@ describe Paperclip::Schema do
         context "with no attachment" do
           it "raises an error" do
             assert_raises ArgumentError do
-              Dummy.connection.remove_attachment :dummies
+              ActiveRecord::Migration.remove_attachment :dummies
             end
           end
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,7 @@ FIXTURES_DIR = File.join(File.dirname(__FILE__), "fixtures")
 config = YAML::safe_load(IO.read(File.dirname(__FILE__) + "/database.yml"))
 ActiveRecord::Base.logger = Logger.new(File.dirname(__FILE__) + "/debug.log")
 ActiveRecord::Base.establish_connection(config["test"])
+ActiveRecord::Migration.verbose = false
 if ActiveRecord::VERSION::STRING >= "4.2" &&
    ActiveRecord::VERSION::STRING < "5.0"
   ActiveRecord::Base.raise_in_transactional_callbacks = true

--- a/spec/support/model_reconstruction.rb
+++ b/spec/support/model_reconstruction.rb
@@ -28,15 +28,15 @@ module ModelReconstruction
 
   def reset_table(_table_name, &block)
     block ||= lambda { |_table| true }
-    ActiveRecord::Base.connection.create_table :dummies, **{ force: true }, &block
+    ActiveRecord::Migration.create_table :dummies, **{ force: true }, &block
   end
 
   def modify_table(&block)
-    ActiveRecord::Base.connection.change_table :dummies, &block
+    ActiveRecord::Migration.change_table :dummies, &block
   end
 
   def rebuild_model(options = {})
-    ActiveRecord::Base.connection.create_table :dummies, force: true do |table|
+    ActiveRecord::Migration.create_table :dummies, force: true do |table|
       table.column :title, :string
       table.column :other, :string
       table.column :avatar_file_name, :string


### PR DESCRIPTION
Currently, projects with old migration files containing Paperclip schema statements do not perform the same schema changes both before and after an ActiveRecord version upgrade.

Consider the following migration file which will add one datetime column using ActiveRecord's `add_column` and another datetime column as part of Paperclip's `add_attachment` (note that is is written as an ActiveRecord 6.1 migration).
```rb
class AddFooAttachmentToBars < ActiveRecord::Migration[6.1]
  def change
    add_column :bars, :baz, :datetime
    add_attachment :bars, :foo
  end
end
```
We would expect the two added datetime columns to be identical in everything but name.

When run on Rails 6.1.7.6 it produces the following schema entry as expected: `baz` and `foo_updated_at` both have the same format
```rb
  create_table "bars", force: :cascade do |t|
    t.datetime "baz"
    t.string "foo_content_type"
    t.string "foo_file_name"
    t.bigint "foo_file_size"
    t.datetime "foo_updated_at"
  end
```
When run on Rails 7.0.8 it produces the following schema entry:  `baz` and `foo_updated_at` have different formats (note that `foo_updated_at` is no longer added with `precision: nil` as it would have in Rails 6)
```rb
  create_table "bars", force: :cascade do |t|
    t.datetime "baz", precision: nil
    t.string "foo_content_type"
    t.string "foo_file_name"
    t.bigint "foo_file_size"
    t.datetime "foo_updated_at"
  end
```
This is because Paperclip schema statements do not currently respect ActiveRecord::Migration::Compatibility versioning; the logic which ensures that schema statements from old migrations retain consistent behaviour when run within newer versions of ActiveRecord.

---

This pull request includes Paperclip::Schema::Statements on ActiveRecord::Migration to ensure that Paperclip schema statements are consistent with ActiveRecord::Migration::Compatibility versioning. 

When run on Rails 6.1.7.6 it produces the following schema entry as expected: `baz` and `foo_updated_at` both have the same format
```rb
  create_table "bars", force: :cascade do |t|
    t.datetime "baz"
    t.string "foo_content_type"
    t.string "foo_file_name"
    t.bigint "foo_file_size"
    t.datetime "foo_updated_at"
  end
```
When run on Rails 7.0.8 it produces the following schema entry as expected: `baz` and `foo_updated_at` both have the same format
```rb
  create_table "bars", force: :cascade do |t|
    t.datetime "baz", precision: nil
    t.string "foo_content_type"
    t.string "foo_file_name"
    t.bigint "foo_file_size"
    t.datetime "foo_updated_at", precision: nil
  end
```

