### PR TITLE
Relax version requirement for `terrapin` gem

### DIFF
--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency("activesupport", ">= 4.2.0")
   s.add_dependency("mime-types")
   s.add_dependency("marcel", "~> 1.0.1")
-  s.add_dependency("terrapin", "~> 0.6.0")
+  s.add_dependency("terrapin")
 
   s.add_development_dependency("activerecord", ">= 4.2.0")
   s.add_development_dependency("appraisal")


### PR DESCRIPTION
Relaxes the version requirement for Terrapin (which released version 1.0.0 recently).

If we need another version here to prevent downgrading or otherwise restrict, I can update.