### PR TITLE
Allow for terrapin 1.x

### DIFF
--- a/paperclip.gemspec
+++ b/paperclip.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency("activesupport", ">= 4.2.0")
   s.add_dependency("mime-types")
   s.add_dependency("marcel", "~> 1.0.1")
-  s.add_dependency("terrapin", "~> 0.6.0")
+  s.add_dependency("terrapin", ">= 0.6.0", "< 2.0")
 
   s.add_development_dependency("activerecord", ">= 4.2.0")
   s.add_development_dependency("appraisal")


### PR DESCRIPTION
Terrapin 1.0.1 was released today with fairly very [little changes](https://github.com/thoughtbot/terrapin/compare/v0.6.0...v1.0.0). It deprecates `Terrapin::CommandLine::PosixRunner` and loosens pinning of `climate_change` gem.

I'd like to loosen the version pinning of `terrapin` so that other indirect dependencies (like climate_change) can be updated.