### PR TITLE
fix frozen string literal deprecation warning

### DIFF
--- a/lib/paperclip/io_adapters/abstract_adapter.rb
+++ b/lib/paperclip/io_adapters/abstract_adapter.rb
@@ -17,7 +17,7 @@ module Paperclip
       @fingerprint ||= begin
         digest = @options.fetch(:hash_digest).new
         File.open(path, "rb") do |f|
-          buf = ""
+          buf = String.new
           digest.update(buf) while f.read(16384, buf)
         end
         digest.hexdigest


### PR DESCRIPTION
implements the suggestion i made in #144 so we don't constantly see this in our logs...

```
/usr/local/bundle/gems/kt-paperclip-7.2.2/lib/paperclip/io_adapters/abstract_adapter.rb:21: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)
```