### PR TITLE
Fix frozen string literal warning in geometry.rb

### DIFF
--- a/lib/paperclip/geometry.rb
+++ b/lib/paperclip/geometry.rb
@@ -72,7 +72,7 @@ module Paperclip
 
     # Returns the width and height in a format suitable to be passed to Geometry.parse
     def to_s
-      s = ""
+      s = String.new
       s << width.to_i.to_s if width > 0
       s << "x#{height.to_i}" if height > 0
       s << modifier.to_s


### PR DESCRIPTION
Following up on #146, fixes another occurrence of a string literal that is mutated, which would be a problem once string literals are frozen in a future Ruby version.