### PR TITLE
Fix the use of deprecated methods from aws-sdk-s3 & Support aws-sdk-s3 >= 1.196.1 and multipart file downloads

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,8 @@
 [UNRELEASED]
 
+* Bugfix: Fix the use of deprecated methods from `aws-sdk-s3`
+* Stability: Dropped support for `aws-sdk-s3` < 1.197.0
+
 7.2.1 (2023-09-09)
 * Improvement: Support file extension names both as symbols and strings for :content_type_mappings
 

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,6 @@
 [UNRELEASED]
 
-* Bugfix: Fix the use of deprecated methods from `aws-sdk-s3`
-* Stability: Dropped support for `aws-sdk-s3` < 1.197.0
+* Improvement: Support aws-sdk-s3 >= 1.196.1 and multipart file downloads
 
 7.2.1 (2023-09-09)
 * Improvement: Support file extension names both as symbols and strings for :content_type_mappings

--- a/lib/paperclip/storage/s3.rb
+++ b/lib/paperclip/storage/s3.rb
@@ -284,7 +284,7 @@ module Paperclip
       def s3_transfer_manager
         @s3_transfer_manager ||= begin
           if ::Aws::S3.const_defined?(:TransferManager, false)
-            ::Aws::S3::TransferManager.new
+            ::Aws::S3::TransferManager.new(client: s3_interface.client)
           else
             nil
           end


### PR DESCRIPTION
I’ve combined both pending PRs on this topic into a single branch with the requested changes, which should be ready for review and merging.
- Pulled changes from https://github.com/kreeti/kt-paperclip/pull/147 and https://github.com/kreeti/kt-paperclip/pull/150 (Thank you @ngan & @fatkodima !)
- Made usage of the new `Aws::S3::TransferManager` conditional, per feedback
- Verified that specs pass with both old and new versions of the `aws-sdk-s3`  gem (note: CI on master is currently broken and will need a separate PR)
- Tested against actual S3 bucket, confirmed that uploads and downloads work correctly with both old and new `aws-sdk-s3` gem versions

This can also be closed if you prefer to merge the individual PRs instead.