### PR TITLE
Fix rubocop style issue

### DIFF
--- a/spec/support/model_reconstruction.rb
+++ b/spec/support/model_reconstruction.rb
@@ -15,9 +15,7 @@ module ModelReconstruction
     klass.reset_column_information
     klass.connection_pool.clear_table_cache!(klass.table_name) if klass.connection_pool.respond_to?(:clear_table_cache!)
 
-    if klass.connection.respond_to?(:schema_cache)
-      klass.connection.schema_cache.clear_data_source_cache!(klass.table_name)
-    end
+    klass.connection.schema_cache.clear_data_source_cache!(klass.table_name) if klass.connection.respond_to?(:schema_cache)
 
     klass
   end


### PR DESCRIPTION
This PR fixes a RuboCop offense in the gem codebase.

## Offense:

```
spec/support/model_reconstruction.rb:18:5: C: [Correctable] Style/IfUnlessModifier: Favor modifier if usage when having a single-line body. Another good alternative is the usage of control flow &&/||.
    if klass.connection.respond_to?(:schema_cache)
    ^^
```

## Changes

updated the condition in spec/support/model_reconstruction.rb to follow RuboCop style guidelines