### PR TITLE
Avoid anonymous evals

### DIFF
--- a/lib/paperclip/callbacks.rb
+++ b/lib/paperclip/callbacks.rb
@@ -11,14 +11,15 @@ module Paperclip
       def define_paperclip_callbacks(*callbacks)
         define_callbacks(*[callbacks, { terminator: hasta_la_vista_baby }].flatten)
         callbacks.each do |callback|
-          eval <<-end_callbacks
-            def before_#{callback}(*args, &blk)
+          class_eval(<<~RUBY, __FILE__, __LINE__ + 1)
+            def self.before_#{callback}(*args, &blk)
               set_callback(:#{callback}, :before, *args, &blk)
             end
-            def after_#{callback}(*args, &blk)
+
+            def self.after_#{callback}(*args, &blk)
               set_callback(:#{callback}, :after, *args, &blk)
             end
-          end_callbacks
+          RUBY
         end
       end
 


### PR DESCRIPTION
Ref: https://github.com/jeremyevans/ruby-warning/pull/29

When generating code with `eval` it's considered best practice to forward `__FILE__` and `__LINE__` so that backtraces and `method(:name).source_location` are easier to work with.